### PR TITLE
docs: update CONTRIBUTING.md, add GitHub bug report template, add .idea folder to .gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Report a reproducible bug or regression in ACS Frontend
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        Please fill out the sections below as precisely as possible. Clear reproduction steps and environment details make triage much faster.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+      placeholder: A short description of what is broken.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps needed to reproduce the issue.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+      placeholder: The page should load without errors.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+      placeholder: The page crashes with a hydration error.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Provide relevant versions and platform details.
+      placeholder: |
+        - OS: Windows 11
+        - Browser: Chrome 135
+        - Node.js: 22.x
+        - npm: 10.x
+        - App version / commit: main@abcdef1
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste console output, stack traces, or add screenshots if they help explain the issue.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues before opening this report.
+          required: true
+        - label: I can reproduce this issue consistently.
+          required: true
+        - label: I understand that sensitive security issues must not be reported publicly.
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.idea/
+.idea/*
+.idea/*.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,13 @@ When contributing documentation:
 
 Documentation updates may affect files such as `README.md`, `CONTRIBUTING.md`, and content under `docs/`.
 
+### Pull Requests
+
+- Keep pull requests focused and small.
+- Link the related issue when possible.
+- Make sure `npm run lint` passes before requesting review.
+- Update documentation when behavior or setup changes.
+
 ## Styleguides
 
 ### Branches

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,164 @@
+<!-- omit in toc -->
+# Contributing to ACS Frontend
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+
+And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+
+> - Star the project
+> - Tweet about it
+> - Refer this project in your project's readme
+> - Mention the project at local meetups and tell your friends/colleagues
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [I Have a Question](#i-have-a-question)
+  - [I Want To Contribute](#i-want-to-contribute)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Improving The Documentation](#improving-the-documentation)
+- [Styleguides](#styleguides)
+  - [Branches](#branches)
+  - [Commit Messages](#commits)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[ACS Frontend Code of Conduct](https://github.com/Team-Caffeine-ACS/acs-frontend/blob/https://github.com/Team-Caffeine-ACS/acs-frontend/tree/main/CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable behavior
+to <andrus@rahni.ee>.
+
+## I Have a Question
+
+> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/Team-Caffeine-ACS).
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/Team-Caffeine-ACS/acs-frontend/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+
+If you then still feel the need to ask a question and need clarification, we recommend the following:
+
+- Open an [Issue](https://github.com/Team-Caffeine-ACS/acs-frontend/issues/new).
+- Provide as much context as you can about what you're running into.
+- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+
+We will then take care of the issue as soon as possible.
+
+To help us triage issues faster, please use the `question` label for support requests when possible. If relevant, also add a scope label such as `documentation`, `api`, `frontend`, `ui`, `layout`, `design`, `accessibility`, `testing`, `workflow`, `CI`, `infrastructure`, or `developer-experience`.
+
+## I Want To Contribute
+
+### Legal Notice
+<!-- omit in toc -->
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project licence.
+
+### Reporting Bugs
+
+<!-- omit in toc -->
+#### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/Team-Caffeine-ACS). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/Team-Caffeine-ACS/acs-frontend/issues?q=label%3Abug).
+- Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
+- Collect information about the bug:
+  - Stack trace (Traceback)
+  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+  - Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
+  - Possibly your input and the output
+  - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Bug Report?
+
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead contact us at first.
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/Team-Caffeine-ACS/acs-frontend/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Provide the information you collected in the previous section.
+
+Once it's filed:
+
+- The project team will label the issue accordingly.
+- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`).
+
+A bug report template is available here: [Bug report issue template](./.github/ISSUE_TEMPLATE/bug_report.yml). Please use it when opening issues so the report includes the information needed for reproduction and triage.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for ACS Frontend, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+<!-- omit in toc -->
+#### Before Submitting an Enhancement
+
+- Make sure that you are using the latest version.
+- Read the [documentation](https://github.com/Team-Caffeine-ACS) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Perform a [search](https://github.com/Team-Caffeine-ACS/acs-frontend/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+
+<!-- omit in toc -->
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/Team-Caffeine-ACS/acs-frontend/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- You may want to **include screenshots or screen recordings** which help you demonstrate the steps or point out the part which the suggestion is related to.
+- **Explain why this enhancement would be useful** to most ACS Frontend users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+
+### Improving The Documentation
+
+Improvements to the documentation are always welcome. This includes fixing typos, clarifying existing instructions, updating outdated examples, and adding missing explanations for setup, project structure, or contribution workflows.
+
+When contributing documentation:
+
+- keep changes concise and accurate
+- prefer updating existing documentation over duplicating information
+- make sure examples and commands match the current project setup
+- use clear language and explain project-specific conventions when needed
+
+Documentation updates may affect files such as `README.md`, `CONTRIBUTING.md`, and content under `docs/`.
+
+## Styleguides
+
+### Branches
+
+- Branch naming format: `<prefix>/<ticket id>-<name of developer>-<brief explanation of what we do in branch>`.
+- There are two categories of branches: the protected long-lived `main` branch and short-lived development
+  branches (for example `feature/*`, `bugfix/*`, etc.). Pushing directly to `main` is prohibited; instead,
+  all work shall be done in these prefixed development branches, reviewed, and merged into `main` with a
+  Pull Request.
+- Prefixes used in project and their explanation:
+
+| Branch pattern | Description |
+| -------------- | ----------- |
+| `main` | Default long-lived branch; all reviewed work is merged here |
+| `feature/*` | New Feature |
+| `bugfix/*` | Bug Fix |
+| `hotfix/*` | Hotfix / Critical Fix |
+| `chore/*` | Technical Maintenance (Refactor / Config / Cleanup) |
+| `refactor/*` | Code Refactoring (No Functional Changes) |
+| `docs/*` | Documentation |
+| `test/*` | Tests (Additions / Improvements) |
+| `ci/*` | CI/CD, GitHub Actions, pipeline |
+| `build/*` | Build-system, dependencies |
+
+Where "\*" is the remaining branch name.
+
+- Branch names should clearly describe the job that is being done in that branch.
+
+### Commits
+
+- Commit messages must clearly describe what was changed in that commit
+- There shouldn't be too many changes in one commit, for more transparent development.
+  (More often commits but smaller is better, than rarer ones and bigger)
+- Commits shall be regularly pushed to GitHub, making the developing more transparent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ And if you like the project, but just don't have time to contribute, that's fine
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the
-[ACS Frontend Code of Conduct](https://github.com/Team-Caffeine-ACS/acs-frontend/blob/https://github.com/Team-Caffeine-ACS/acs-frontend/tree/main/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. Please report unacceptable behavior
-to <andrus@rahni.ee>.
+Everyone contributing to ACS Frontend, whether as a team member or external contributor, is expected to be respectful, constructive, and professional.
+Treat others with courtesy, welcome good-faith feedback, and keep discussions focused on the work rather than the person.
+Harassment, discrimination, personal attacks, or sharing private or sensitive information are not acceptable.
+If you experience or witness unacceptable behavior, please raise it through GitHub Discussions.
 
 ## I Have a Question
 
@@ -85,14 +85,14 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://github.com/Team-Caffeine-ACS/acs-frontend/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open the [Bug report issue form](https://github.com/Team-Caffeine-ACS/acs-frontend/issues/new/choose) and fill in all required fields.
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 
 Once it's filed:
 
-- The project team will label the issue accordingly.
+- The bug report template adds the `bug` label automatically. The project team may then add additional labels such as `needs-repro`, `needs-fix`, or `critical` as needed.
 - A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
 - If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`).
 
@@ -138,6 +138,7 @@ Documentation updates may affect files such as `README.md`, `CONTRIBUTING.md`, a
 
 ### Pull Requests
 
+- Use the [Pull Request template](https://github.com/Team-Caffeine-ACS/acs-frontend/blob/main/.github/pull_request_template.md) when opening a pull request.
 - Keep pull requests focused and small.
 - Link the related issue when possible.
 - Make sure `npm run lint` passes before requesting review.
@@ -173,7 +174,13 @@ Where "\*" is the remaining branch name.
 
 ### Commits
 
-- Commit messages must clearly describe what was changed in that commit
+- Use the Conventional Commits format: `<type>: <short description>`.
+- Supported types include `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, and `build`.
+- Examples:
+  - `feat: add booking calendar`
+  - `fix: resolve hydration mismatch on homepage`
+  - `docs: clarify branch naming rules`
+- This format keeps commit history consistent and makes automated changelog generation easier.
 - There shouldn't be too many changes in one commit, for more transparent development.
   (More often commits but smaller is better, than rarer ones and bigger)
 - Commits shall be regularly pushed to GitHub, making the developing more transparent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 <!-- omit in toc -->
+
 # Contributing to ACS Frontend
 
 First off, thanks for taking the time to contribute! ❤️
@@ -13,6 +14,7 @@ And if you like the project, but just don't have time to contribute, that's fine
 > - Mention the project at local meetups and tell your friends/colleagues
 
 <!-- omit in toc -->
+
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
@@ -51,12 +53,15 @@ To help us triage issues faster, please use the `question` label for support req
 ## I Want To Contribute
 
 ### Legal Notice
+
 <!-- omit in toc -->
+
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project licence.
 
 ### Reporting Bugs
 
 <!-- omit in toc -->
+
 #### Before Submitting a Bug Report
 
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
@@ -73,6 +78,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
   - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
 
 <!-- omit in toc -->
+
 #### How Do I Submit a Good Bug Report?
 
 > You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead contact us at first.
@@ -81,7 +87,7 @@ We use GitHub issues to track bugs and errors. If you run into an issue with the
 
 - Open an [Issue](https://github.com/Team-Caffeine-ACS/acs-frontend/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
-- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 
 Once it's filed:
@@ -97,6 +103,7 @@ A bug report template is available here: [Bug report issue template](./.github/I
 This section guides you through submitting an enhancement suggestion for ACS Frontend, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
 
 <!-- omit in toc -->
+
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
@@ -105,6 +112,7 @@ This section guides you through submitting an enhancement suggestion for ACS Fro
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 <!-- omit in toc -->
+
 #### How Do I Submit a Good Enhancement Suggestion?
 
 Enhancement suggestions are tracked as [GitHub issues](https://github.com/Team-Caffeine-ACS/acs-frontend/issues).
@@ -139,18 +147,18 @@ Documentation updates may affect files such as `README.md`, `CONTRIBUTING.md`, a
   Pull Request.
 - Prefixes used in project and their explanation:
 
-| Branch pattern | Description |
-| -------------- | ----------- |
-| `main` | Default long-lived branch; all reviewed work is merged here |
-| `feature/*` | New Feature |
-| `bugfix/*` | Bug Fix |
-| `hotfix/*` | Hotfix / Critical Fix |
-| `chore/*` | Technical Maintenance (Refactor / Config / Cleanup) |
-| `refactor/*` | Code Refactoring (No Functional Changes) |
-| `docs/*` | Documentation |
-| `test/*` | Tests (Additions / Improvements) |
-| `ci/*` | CI/CD, GitHub Actions, pipeline |
-| `build/*` | Build-system, dependencies |
+| Branch pattern | Description                                                 |
+| -------------- | ----------------------------------------------------------- |
+| `main`         | Default long-lived branch; all reviewed work is merged here |
+| `feature/*`    | New Feature                                                 |
+| `bugfix/*`     | Bug Fix                                                     |
+| `hotfix/*`     | Hotfix / Critical Fix                                       |
+| `chore/*`      | Technical Maintenance (Refactor / Config / Cleanup)         |
+| `refactor/*`   | Code Refactoring (No Functional Changes)                    |
+| `docs/*`       | Documentation                                               |
+| `test/*`       | Tests (Additions / Improvements)                            |
+| `ci/*`         | CI/CD, GitHub Actions, pipeline                             |
+| `build/*`      | Build-system, dependencies                                  |
 
 Where "\*" is the remaining branch name.
 


### PR DESCRIPTION
docs(contributing): improve contribution guide and add bug report template

Clarify how contributors should use repository labels when opening issues and replace placeholder comments in CONTRIBUTING.md with concrete guidance.

Add a GitHub bug report issue template to collect the information needed for reproduction and triage, including steps to reproduce, expected and actual behaviour, environment details, and relevant logs.

Also link the new issue template from CONTRIBUTING.md so contributors can find and use it more easily.

Done within 2h.