### PR TITLE
fix(config): align API base URL env variable across frontend

### DIFF
--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 const LOG = process.env.NEXT_PUBLIC_DEBUG === "true";
 
 export class ApiError extends Error {


### PR DESCRIPTION
# Description

## Summary

This PR aligns the frontend API base URL environment variable across the codebase so the login flow uses the local backend correctly.

### Why

The login page could fail against `http://localhost:8080` because the frontend code, local env files, and documentation were not using the same environment variable name for the API base URL. That mismatch caused the client to fall back to an empty base URL and send requests to the frontend origin instead of the backend.

### Related Issue

Closes the bug about login using the wrong API base URL due to env variable mismatch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Styling / UI update
- [ ] Other

## Checklist

- [x] I reviewed my own changes
- [x] I added or updated documentation where needed
- [x] I ran `npm run lint`
- [ ] I ran `npx prettier --check .`
- [x] My changes were tested locally
- [ ] I linked the related issue
- [x] This PR is ready for review

## Screenshots

N/A

## Additional Notes

This PR standardizes on `NEXT_PUBLIC_API_URL` in:
- `lib/apiClient.ts`
- `.env.example`
- `.env.local`
- `README.md`

If reviewers pull this branch while already running `next dev`, they should restart the dev server so the updated env value is reloaded.
