### PR TITLE
Feat/54 create keycard information page

### DIFF
--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -99,11 +99,16 @@ export default function KeycardDetailsPage() {
     );
   }
 
-  const currentStateText = keycard.assignedUser
-    ? "Kaart on hetkel välja antud. Aktiivne hoidja ja väljastamise aeg on teada."
-    : keycard.lastReturnTime
-      ? "Kaart ei ole hetkel välja antud. Viimane teadaolev sündmus on tagastus."
-      : "Kaardil ei ole praegu aktiivset hoidjat ega tagastusajalugu.";
+  let currentStateText =
+    "Kaardil ei ole praegu aktiivset hoidjat ega tagastusajalugu.";
+
+  if (keycard.assignedUser) {
+    currentStateText =
+      "Kaart on hetkel välja antud. Aktiivne hoidja ja väljastamise aeg on teada.";
+  } else if (keycard.lastReturnTime) {
+    currentStateText =
+      "Kaart ei ole hetkel välja antud. Viimane teadaolev sündmus on tagastus.";
+  }
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 animate-in fade-in duration-500">

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -133,7 +133,7 @@ export default function KeycardDetailsPage() {
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-3">
               <h1 className="font-display text-3xl font-black tracking-tight text-slate-900">
-                Kiipkaardi üksikasjad
+                Võtmekaardi üksikasjad
               </h1>
               <StatusBadge status={keycard.status} />
             </div>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -85,7 +85,9 @@ export default function KeycardDetailsPage() {
   }
 
   if (error) {
-    return <PageState title="Detailvaadet ei saanud avada" description={error} />;
+    return (
+      <PageState title="Detailvaadet ei saanud avada" description={error} />
+    );
   }
 
   if (isNotFound || !keycard) {
@@ -145,8 +147,8 @@ export default function KeycardDetailsPage() {
         <div className="flex items-start gap-2">
           <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
           <p>
-            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab
-            aktiivse hoidja, hoidja `person_in_role` ID ning viimased teadaolevad
+            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab aktiivse
+            hoidja, hoidja `person_in_role` ID ning viimased teadaolevad
             väljastus- või tagastusajad. Väljastaja, vastuvõtulaud ja täielik
             ajalugu ei tule sellest response’ist veel kaasa.
           </p>
@@ -160,7 +162,10 @@ export default function KeycardDetailsPage() {
             title="Kaardi informatsioon"
           >
             <div className="grid gap-5 md:grid-cols-2">
-              <DetailField label="Kaardi number" value={keycard.keycardNumber} />
+              <DetailField
+                label="Kaardi number"
+                value={keycard.keycardNumber}
+              />
               <DetailField
                 label="Staatus"
                 value={getKeycardStatusLabel(keycard.status)}

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -162,19 +162,6 @@ export default function KeycardDetailsPage() {
         </div>
       </div>
 
-      <div className="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-slate-700">
-        <div className="flex items-start gap-2">
-          <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
-          <p>
-            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab aktiivse
-            kaardi kasutaja, kaardi kasutaja `person_in_role` ID ning viimased
-            teadaolevad väljastus- või tagastusajad. Kaardi kasutaja rolli
-            nimetust, väljastajat, vastuvõtulauda ja täielikku ajalugu sellest
-            response’ist veel ei tule.
-          </p>
-        </div>
-      </div>
-
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <div className="space-y-6">
           <SectionCard
@@ -229,7 +216,7 @@ export default function KeycardDetailsPage() {
 
         <SectionCard
           icon={<HistoryIcon className="!text-lg text-primary" />}
-          title="Ajaloo kokkuvõte"
+          title="Ajajoon"
         >
           <div className="space-y-4">
             <SummaryEvent
@@ -250,11 +237,6 @@ export default function KeycardDetailsPage() {
               description="Tagastatud kaardi korral näitab backend viimase tagastuse aega."
               accentClass="border-amber-200 bg-amber-50 text-amber-700"
             />
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600">
-              Täieliku issue/return ajaloo, väljastaja ja vastuvõtulaua
-              kuvamiseks on vaja eraldi history-andmeid või detailsemat
-              response’i backendist.
-            </div>
           </div>
         </SectionCard>
       </div>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -166,11 +166,11 @@ export default function KeycardDetailsPage() {
         <div className="flex items-start gap-2">
           <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
           <p>
-            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab
-            aktiivse kaardi kasutaja, kaardi kasutaja `person_in_role` ID ning
-            viimased teadaolevad väljastus- või tagastusajad. Kaardi kasutaja
-            rolli nimetust, väljastajat, vastuvõtulauda ja täielikku ajalugu
-            sellest response’ist veel ei tule.
+            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab aktiivse
+            kaardi kasutaja, kaardi kasutaja `person_in_role` ID ning viimased
+            teadaolevad väljastus- või tagastusajad. Kaardi kasutaja rolli
+            nimetust, väljastajat, vastuvõtulauda ja täielikku ajalugu sellest
+            response’ist veel ei tule.
           </p>
         </div>
       </div>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -11,7 +11,6 @@ import LinkIcon from "@mui/icons-material/Link";
 import HistoryIcon from "@mui/icons-material/History";
 import EventAvailableIcon from "@mui/icons-material/EventAvailable";
 import AssignmentReturnIcon from "@mui/icons-material/AssignmentReturn";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/apiClient";
 import {

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -175,14 +175,17 @@ export default function KeycardDetailsPage() {
               <DetailField
                 label="Staatus"
                 value={getKeycardStatusLabel(keycard.status)}
+                tone={keycard.status === "available" ? "success" : "default"}
               />
               <DetailField
                 label="Aktiivne"
                 value={keycard.active ? "Jah" : "Ei"}
+                tone={keycard.active ? "success" : "default"}
               />
               <DetailField
                 label="Kehtib kuni"
                 value={formatDateTime(keycard.validUntil, "Määramata")}
+                isMissing={!keycard.validUntil}
               />
             </div>
           </SectionCard>
@@ -196,18 +199,22 @@ export default function KeycardDetailsPage() {
                 label="Kaardi kasutaja"
                 value={keycard.assignedUser ?? "Aktiivne kasutaja puudub"}
                 accent={Boolean(keycard.assignedUser)}
+                isMissing={!keycard.assignedUser}
               />
               <DetailField
                 label="Kaardi kasutaja roll"
                 value={getAssignedRoleLabel(keycard.assignedPersonInRoleId)}
+                isMissing={!keycard.assignedPersonInRoleId}
               />
               <DetailField
                 label="Väljastamise aeg"
                 value={formatDateTime(keycard.assignedTime, "Puudub")}
+                isMissing={!keycard.assignedTime}
               />
               <DetailField
                 label="Viimati tagastatud"
                 value={formatDateTime(keycard.lastReturnTime, "Puudub")}
+                isMissing={!keycard.lastReturnTime}
               />
             </div>
           </SectionCard>
@@ -286,21 +293,35 @@ function DetailField({
   label,
   value,
   accent = false,
+  isMissing = false,
+  tone = "default",
 }: Readonly<{
   label: string;
   value: string;
   accent?: boolean;
+  isMissing?: boolean;
+  tone?: "default" | "success";
 }>) {
+  const containerClass = isMissing
+    ? "bg-slate-100 text-slate-500"
+    : tone === "success"
+      ? "bg-emerald-50"
+      : "bg-slate-50";
+
+  const valueClass = isMissing
+    ? "text-slate-500"
+    : tone === "success"
+      ? "text-emerald-700"
+      : accent
+        ? "text-primary"
+        : "text-slate-900";
+
   return (
-    <div className="space-y-1 rounded-2xl bg-slate-50 px-4 py-4">
+    <div className={`space-y-1 rounded-2xl px-4 py-4 ${containerClass}`}>
       <p className="text-[10px] font-black uppercase tracking-widest text-slate-400">
         {label}
       </p>
-      <p
-        className={`break-all text-sm font-semibold ${accent ? "text-primary" : "text-slate-900"}`}
-      >
-        {value}
-      </p>
+      <p className={`break-all text-sm font-semibold ${valueClass}`}>{value}</p>
     </div>
   );
 }

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -225,7 +225,7 @@ export default function KeycardDetailsPage() {
               description={
                 keycard.assignedUser
                   ? `Kaart on hetkel välja antud kasutajale ${keycard.assignedUser}.`
-                  : "Kui kaart ei ole aktiivselt välja antud, on see väli null."
+                  : undefined
               }
               accentClass="border-blue-200 bg-blue-50 text-blue-700"
             />
@@ -233,7 +233,6 @@ export default function KeycardDetailsPage() {
               icon={<AssignmentReturnIcon className="!text-base" />}
               title="Viimane tagastus"
               value={formatDateTime(keycard.lastReturnTime, "Puudub")}
-              description="Tagastatud kaardi korral näitab backend viimase tagastuse aega."
               accentClass="border-amber-200 bg-amber-50 text-amber-700"
             />
           </div>
@@ -316,7 +315,7 @@ function SummaryEvent({
   icon: ReactNode;
   title: string;
   value: string;
-  description: string;
+  description?: string;
   accentClass: string;
 }>) {
   return (
@@ -332,7 +331,9 @@ function SummaryEvent({
           <div>
             <p className="text-sm font-bold text-slate-900">{title}</p>
             <p className="mt-1 text-sm font-semibold text-slate-700">{value}</p>
-            <p className="mt-2 text-sm text-slate-500">{description}</p>
+            {description ? (
+              <p className="mt-2 text-sm text-slate-500">{description}</p>
+            ) : null}
           </div>
         </div>
       </div>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { type ReactNode, useEffect, useState } from "react";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import CreditCardIcon from "@mui/icons-material/CreditCard";
+import PersonIcon from "@mui/icons-material/Person";
+import LinkIcon from "@mui/icons-material/Link";
+import HistoryIcon from "@mui/icons-material/History";
+import EventAvailableIcon from "@mui/icons-material/EventAvailable";
+import AssignmentReturnIcon from "@mui/icons-material/AssignmentReturn";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/apiClient";
+import {
+  getKeycard,
+  getKeycardStatusLabel,
+  type KeycardDetailResponse,
+} from "@/lib/api/keycards";
+
+export default function KeycardDetailsPage() {
+  const params = useParams<{ id: string }>();
+  const keycardId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const [keycard, setKeycard] = useState<KeycardDetailResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isNotFound, setIsNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!keycardId) {
+      setIsLoading(false);
+      setIsNotFound(true);
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadKeycard = async () => {
+      setIsLoading(true);
+      setError(null);
+      setIsNotFound(false);
+
+      try {
+        const detail = await getKeycard(keycardId);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setKeycard(detail);
+      } catch (err) {
+        if (!isMounted) {
+          return;
+        }
+
+        if (err instanceof ApiError && err.status === 404) {
+          setIsNotFound(true);
+          return;
+        }
+
+        setError(
+          err instanceof ApiError
+            ? err.message
+            : "Võtmekaardi detailide laadimine ebaõnnestus.",
+        );
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadKeycard();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [keycardId]);
+
+  if (isLoading) {
+    return <PageState title="Laen võtmekaardi andmeid..." />;
+  }
+
+  if (error) {
+    return <PageState title="Detailvaadet ei saanud avada" description={error} />;
+  }
+
+  if (isNotFound || !keycard) {
+    return (
+      <PageState
+        title="Võtmekaarti ei leitud"
+        description="Kontrolli, kas valitud kaart on süsteemis olemas või ava see nimekirjast uuesti."
+      />
+    );
+  }
+
+  const currentStateText = keycard.assignedUser
+    ? "Kaart on hetkel välja antud. Aktiivne hoidja ja väljastamise aeg on teada."
+    : keycard.lastReturnTime
+      ? "Kaart ei ole hetkel välja antud. Viimane teadaolev sündmus on tagastus."
+      : "Kaardil ei ole praegu aktiivset hoidjat ega tagastusajalugu.";
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 animate-in fade-in duration-500">
+      <div className="space-y-4">
+        <nav className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
+          <Link href="/" className="transition-colors hover:text-primary">
+            Pääsla
+          </Link>
+          <ChevronRightIcon className="!text-sm" />
+          <Link href="/keys" className="transition-colors hover:text-primary">
+            Võtmekaardid
+          </Link>
+          <ChevronRightIcon className="!text-sm" />
+          <span className="text-primary">{keycard.keycardNumber}</span>
+        </nav>
+
+        <div className="flex flex-col justify-between gap-4 md:flex-row md:items-start">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="font-display text-3xl font-black tracking-tight text-slate-900">
+                Kiipkaardi üksikasjad
+              </h1>
+              <StatusBadge status={keycard.status} />
+            </div>
+            <p className="text-sm font-semibold uppercase tracking-widest text-slate-400">
+              ID: {keycard.keycardNumber}
+            </p>
+            <p className="max-w-2xl text-slate-500">{currentStateText}</p>
+          </div>
+
+          <Button asChild variant="outline" className="gap-2 rounded-xl">
+            <Link href="/keys">
+              <ArrowBackIcon className="!text-base" />
+              Tagasi nimekirja
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-slate-700">
+        <div className="flex items-start gap-2">
+          <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
+          <p>
+            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab
+            aktiivse hoidja, hoidja `person_in_role` ID ning viimased teadaolevad
+            väljastus- või tagastusajad. Väljastaja, vastuvõtulaud ja täielik
+            ajalugu ei tule sellest response’ist veel kaasa.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-6">
+          <SectionCard
+            icon={<CreditCardIcon className="!text-lg text-primary" />}
+            title="Kaardi informatsioon"
+          >
+            <div className="grid gap-5 md:grid-cols-2">
+              <DetailField label="Kaardi number" value={keycard.keycardNumber} />
+              <DetailField
+                label="Staatus"
+                value={getKeycardStatusLabel(keycard.status)}
+              />
+              <DetailField
+                label="Aktiivne"
+                value={keycard.active ? "Jah" : "Ei"}
+              />
+              <DetailField
+                label="Kehtib kuni"
+                value={formatDateTime(keycard.validUntil, "Määramata")}
+              />
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            icon={<PersonIcon className="!text-lg text-primary" />}
+            title="Määramise üksikasjad"
+          >
+            <div className="grid gap-5 md:grid-cols-2">
+              <DetailField
+                label="Praegune kasutaja"
+                value={keycard.assignedUser ?? "Aktiivne kasutaja puudub"}
+                accent={Boolean(keycard.assignedUser)}
+              />
+              <DetailField
+                label="Hoidja person_in_role ID"
+                value={keycard.assignedPersonInRoleId ?? "Seos puudub"}
+              />
+              <DetailField
+                label="Väljastamise aeg"
+                value={formatDateTime(keycard.assignedTime, "Puudub")}
+              />
+              <DetailField
+                label="Viimati tagastatud"
+                value={formatDateTime(keycard.lastReturnTime, "Puudub")}
+              />
+              <DetailField
+                label="Külastaja seos"
+                value={
+                  keycard.assignedPersonInRoleId
+                    ? "Aktiivne"
+                    : "Eemaldatud või puudub"
+                }
+              />
+            </div>
+          </SectionCard>
+        </div>
+
+        <SectionCard
+          icon={<HistoryIcon className="!text-lg text-primary" />}
+          title="Ajaloo kokkuvõte"
+        >
+          <div className="space-y-4">
+            <SummaryEvent
+              icon={<EventAvailableIcon className="!text-base" />}
+              title="Praegune või viimane väljastus"
+              value={formatDateTime(keycard.assignedTime, "Puudub")}
+              description={
+                keycard.assignedUser
+                  ? `Kaart on hetkel välja antud kasutajale ${keycard.assignedUser}.`
+                  : "Kui kaart ei ole aktiivselt välja antud, on see väli null."
+              }
+              accentClass="border-blue-200 bg-blue-50 text-blue-700"
+            />
+            <SummaryEvent
+              icon={<AssignmentReturnIcon className="!text-base" />}
+              title="Viimane tagastus"
+              value={formatDateTime(keycard.lastReturnTime, "Puudub")}
+              description="Tagastatud kaardi korral näitab backend viimase tagastuse aega."
+              accentClass="border-amber-200 bg-amber-50 text-amber-700"
+            />
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600">
+              Täieliku issue/return ajaloo, väljastaja ja vastuvõtulaua
+              kuvamiseks on vaja eraldi history-andmeid või detailsemat
+              response’i backendist.
+            </div>
+          </div>
+        </SectionCard>
+      </div>
+    </div>
+  );
+}
+
+function PageState({
+  title,
+  description,
+}: Readonly<{
+  title: string;
+  description?: string;
+}>) {
+  return (
+    <div className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center">
+      <div className="rounded-3xl border border-slate-200 bg-white px-8 py-10 text-center shadow-sm">
+        <p className="text-lg font-bold text-slate-900">{title}</p>
+        {description ? (
+          <p className="mt-2 max-w-lg text-sm text-slate-500">{description}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SectionCard({
+  icon,
+  title,
+  children,
+}: Readonly<{
+  icon: ReactNode;
+  title: string;
+  children: ReactNode;
+}>) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="mb-5 flex items-center gap-2">
+        <h2 className="flex items-center gap-2 text-sm font-black uppercase tracking-widest text-slate-500">
+          {icon} {title}
+        </h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function DetailField({
+  label,
+  value,
+  accent = false,
+}: Readonly<{
+  label: string;
+  value: string;
+  accent?: boolean;
+}>) {
+  return (
+    <div className="space-y-1 rounded-2xl bg-slate-50 px-4 py-4">
+      <p className="text-[10px] font-black uppercase tracking-widest text-slate-400">
+        {label}
+      </p>
+      <p
+        className={`break-all text-sm font-semibold ${accent ? "text-primary" : "text-slate-900"}`}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function SummaryEvent({
+  icon,
+  title,
+  value,
+  description,
+  accentClass,
+}: Readonly<{
+  icon: ReactNode;
+  title: string;
+  value: string;
+  description: string;
+  accentClass: string;
+}>) {
+  return (
+    <div className="flex gap-4">
+      <div
+        className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border ${accentClass}`}
+      >
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1 rounded-2xl bg-slate-50 px-4 py-4">
+        <div className="flex items-start gap-2">
+          <LinkIcon className="mt-0.5 !text-base text-slate-400" />
+          <div>
+            <p className="text-sm font-bold text-slate-900">{title}</p>
+            <p className="mt-1 text-sm font-semibold text-slate-700">{value}</p>
+            <p className="mt-2 text-sm text-slate-500">{description}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+}: Readonly<{ status: KeycardDetailResponse["status"] }>) {
+  const styles: Record<KeycardDetailResponse["status"], string> = {
+    available: "border-emerald-100 bg-emerald-50 text-emerald-700",
+    in_use: "border-blue-100 bg-blue-50 text-blue-700",
+    disabled: "border-rose-100 bg-rose-50 text-rose-700",
+  };
+
+  return (
+    <span
+      className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-widest ${styles[status]}`}
+    >
+      {getKeycardStatusLabel(status)}
+    </span>
+  );
+}
+
+function formatDateTime(value: string | null, emptyLabel: string): string {
+  if (!value) {
+    return emptyLabel;
+  }
+
+  return new Intl.DateTimeFormat("et-EE", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -314,7 +314,7 @@ function DetailField({
             ? "bg-rose-50"
             : tone === "muted"
               ? "bg-slate-100"
-      : "bg-slate-50";
+              : "bg-slate-50";
 
   const valueClass = isMissing
     ? "text-slate-500"
@@ -328,9 +328,9 @@ function DetailField({
             ? "text-rose-700"
             : tone === "muted"
               ? "text-slate-600"
-      : accent
-        ? "text-primary"
-        : "text-slate-900";
+              : accent
+                ? "text-primary"
+                : "text-slate-900";
 
   return (
     <div className={`space-y-1 rounded-2xl px-4 py-4 ${containerClass}`}>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -100,11 +100,11 @@ export default function KeycardDetailsPage() {
   }
 
   let currentStateText =
-    "Kaardil ei ole praegu aktiivset hoidjat ega tagastusajalugu.";
+    "Kaardil ei ole praegu aktiivset kasutajat ega tagastusajalugu.";
 
   if (keycard.assignedUser) {
     currentStateText =
-      "Kaart on hetkel välja antud. Aktiivne hoidja ja väljastamise aeg on teada.";
+      "Kaart on hetkel välja antud. Aktiivne kaardi kasutaja ja väljastamise aeg on teada.";
   } else if (keycard.lastReturnTime) {
     currentStateText =
       "Kaart ei ole hetkel välja antud. Viimane teadaolev sündmus on tagastus.";
@@ -152,10 +152,11 @@ export default function KeycardDetailsPage() {
         <div className="flex items-start gap-2">
           <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
           <p>
-            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab aktiivse
-            hoidja, hoidja `person_in_role` ID ning viimased teadaolevad
-            väljastus- või tagastusajad. Väljastaja, vastuvõtulaud ja täielik
-            ajalugu ei tule sellest response’ist veel kaasa.
+            Praegune `GET /api/keycards/{"{cardId}"}` endpoint tagastab
+            aktiivse kaardi kasutaja, kaardi kasutaja `person_in_role` ID ning
+            viimased teadaolevad väljastus- või tagastusajad. Kaardi kasutaja
+            rolli nimetust, väljastajat, vastuvõtulauda ja täielikku ajalugu
+            sellest response’ist veel ei tule.
           </p>
         </div>
       </div>
@@ -192,13 +193,13 @@ export default function KeycardDetailsPage() {
           >
             <div className="grid gap-5 md:grid-cols-2">
               <DetailField
-                label="Praegune kasutaja"
+                label="Kaardi kasutaja"
                 value={keycard.assignedUser ?? "Aktiivne kasutaja puudub"}
                 accent={Boolean(keycard.assignedUser)}
               />
               <DetailField
-                label="Hoidja person_in_role ID"
-                value={keycard.assignedPersonInRoleId ?? "Seos puudub"}
+                label="Kaardi kasutaja roll"
+                value={getAssignedRoleLabel(keycard.assignedPersonInRoleId)}
               />
               <DetailField
                 label="Väljastamise aeg"
@@ -207,14 +208,6 @@ export default function KeycardDetailsPage() {
               <DetailField
                 label="Viimati tagastatud"
                 value={formatDateTime(keycard.lastReturnTime, "Puudub")}
-              />
-              <DetailField
-                label="Külastaja seos"
-                value={
-                  keycard.assignedPersonInRoleId
-                    ? "Aktiivne"
-                    : "Eemaldatud või puudub"
-                }
               />
             </div>
           </SectionCard>
@@ -379,4 +372,12 @@ function formatDateTime(value: string | null, emptyLabel: string): string {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value));
+}
+
+function getAssignedRoleLabel(assignedPersonInRoleId: string | null): string {
+  if (!assignedPersonInRoleId) {
+    return "Puudub";
+  }
+
+  return "Pole detailvaates saadaval";
 }

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -137,7 +137,7 @@ export default function KeycardDetailsPage() {
               <StatusBadge status={keycard.status} />
             </div>
             <p className="text-sm font-semibold uppercase tracking-widest text-slate-400">
-              ID: {keycard.keycardNumber}
+              ID: {keycard.id}
             </p>
             <p className="max-w-2xl text-slate-500">{currentStateText}</p>
           </div>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -110,6 +110,10 @@ export default function KeycardDetailsPage() {
       "Kaart ei ole hetkel välja antud. Viimane teadaolev sündmus on tagastus.";
   }
 
+  const canReturnKeycard =
+    keycard.status === "in_use" &&
+    Boolean(keycard.assignedUser || keycard.assignedTime);
+
   return (
     <div className="mx-auto max-w-7xl space-y-6 animate-in fade-in duration-500">
       <div className="space-y-4">
@@ -139,12 +143,22 @@ export default function KeycardDetailsPage() {
             <p className="max-w-2xl text-slate-500">{currentStateText}</p>
           </div>
 
-          <Button asChild variant="outline" className="gap-2 rounded-xl">
-            <Link href="/keys">
-              <ArrowBackIcon className="!text-base" />
-              Tagasi nimekirja
-            </Link>
-          </Button>
+          <div className="flex flex-wrap gap-3">
+            {canReturnKeycard ? (
+              <Button asChild className="gap-2 rounded-xl">
+                <Link href={`/keys/${keycard.id}/return`}>
+                  <AssignmentReturnIcon className="!text-base" />
+                  Tagasta kaart
+                </Link>
+              </Button>
+            ) : null}
+            <Button asChild variant="outline" className="gap-2 rounded-xl">
+              <Link href="/keys">
+                <ArrowBackIcon className="!text-base" />
+                Tagasi nimekirja
+              </Link>
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -175,12 +175,12 @@ export default function KeycardDetailsPage() {
               <DetailField
                 label="Staatus"
                 value={getKeycardStatusLabel(keycard.status)}
-                tone={keycard.status === "available" ? "success" : "default"}
+                tone={getStatusFieldTone(keycard.status)}
               />
               <DetailField
                 label="Aktiivne"
                 value={keycard.active ? "Jah" : "Ei"}
-                tone={keycard.active ? "success" : "default"}
+                tone={keycard.active ? "success" : "danger"}
               />
               <DetailField
                 label="Kehtib kuni"
@@ -300,18 +300,34 @@ function DetailField({
   value: string;
   accent?: boolean;
   isMissing?: boolean;
-  tone?: "default" | "success";
+  tone?: "default" | "success" | "info" | "warning" | "danger" | "muted";
 }>) {
   const containerClass = isMissing
     ? "bg-slate-100 text-slate-500"
     : tone === "success"
       ? "bg-emerald-50"
+      : tone === "info"
+        ? "bg-blue-50"
+        : tone === "warning"
+          ? "bg-amber-50"
+          : tone === "danger"
+            ? "bg-rose-50"
+            : tone === "muted"
+              ? "bg-slate-100"
       : "bg-slate-50";
 
   const valueClass = isMissing
     ? "text-slate-500"
     : tone === "success"
       ? "text-emerald-700"
+      : tone === "info"
+        ? "text-blue-700"
+        : tone === "warning"
+          ? "text-amber-700"
+          : tone === "danger"
+            ? "text-rose-700"
+            : tone === "muted"
+              ? "text-slate-600"
       : accent
         ? "text-primary"
         : "text-slate-900";
@@ -369,6 +385,7 @@ function StatusBadge({
     available: "border-emerald-100 bg-emerald-50 text-emerald-700",
     in_use: "border-blue-100 bg-blue-50 text-blue-700",
     disabled: "border-rose-100 bg-rose-50 text-rose-700",
+    expired: "border-amber-100 bg-amber-50 text-amber-700",
   };
 
   return (
@@ -378,6 +395,21 @@ function StatusBadge({
       {getKeycardStatusLabel(status)}
     </span>
   );
+}
+
+function getStatusFieldTone(
+  status: KeycardDetailResponse["status"],
+): "info" | "warning" | "danger" | "muted" {
+  switch (status) {
+    case "available":
+      return "info";
+    case "in_use":
+      return "warning";
+    case "disabled":
+      return "danger";
+    case "expired":
+      return "warning";
+  }
 }
 
 function formatDateTime(value: string | null, emptyLabel: string): string {

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -155,7 +155,7 @@ export default function KeycardDetailsPage() {
             <Button asChild variant="outline" className="gap-2 rounded-xl">
               <Link href="/keys">
                 <ArrowBackIcon className="!text-base" />
-                Tagasi nimekirja
+                Tagasi
               </Link>
             </Button>
           </div>

--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -300,37 +300,13 @@ function DetailField({
   value: string;
   accent?: boolean;
   isMissing?: boolean;
-  tone?: "default" | "success" | "info" | "warning" | "danger" | "muted";
+  tone?: DetailFieldTone;
 }>) {
-  const containerClass = isMissing
-    ? "bg-slate-100 text-slate-500"
-    : tone === "success"
-      ? "bg-emerald-50"
-      : tone === "info"
-        ? "bg-blue-50"
-        : tone === "warning"
-          ? "bg-amber-50"
-          : tone === "danger"
-            ? "bg-rose-50"
-            : tone === "muted"
-              ? "bg-slate-100"
-              : "bg-slate-50";
-
-  const valueClass = isMissing
-    ? "text-slate-500"
-    : tone === "success"
-      ? "text-emerald-700"
-      : tone === "info"
-        ? "text-blue-700"
-        : tone === "warning"
-          ? "text-amber-700"
-          : tone === "danger"
-            ? "text-rose-700"
-            : tone === "muted"
-              ? "text-slate-600"
-              : accent
-                ? "text-primary"
-                : "text-slate-900";
+  const { containerClass, valueClass } = getDetailFieldClasses({
+    accent,
+    isMissing,
+    tone,
+  });
 
   return (
     <div className={`space-y-1 rounded-2xl px-4 py-4 ${containerClass}`}>
@@ -340,6 +316,57 @@ function DetailField({
       <p className={`break-all text-sm font-semibold ${valueClass}`}>{value}</p>
     </div>
   );
+}
+
+type DetailFieldTone =
+  | "default"
+  | "success"
+  | "info"
+  | "warning"
+  | "danger"
+  | "muted";
+
+const detailFieldContainerToneClass: Record<DetailFieldTone, string> = {
+  default: "bg-slate-50",
+  success: "bg-emerald-50",
+  info: "bg-blue-50",
+  warning: "bg-amber-50",
+  danger: "bg-rose-50",
+  muted: "bg-slate-100",
+};
+
+const detailFieldValueToneClass: Record<DetailFieldTone, string> = {
+  default: "text-slate-900",
+  success: "text-emerald-700",
+  info: "text-blue-700",
+  warning: "text-amber-700",
+  danger: "text-rose-700",
+  muted: "text-slate-600",
+};
+
+function getDetailFieldClasses({
+  accent,
+  isMissing,
+  tone,
+}: Readonly<{
+  accent: boolean;
+  isMissing: boolean;
+  tone: DetailFieldTone;
+}>) {
+  if (isMissing) {
+    return {
+      containerClass: "bg-slate-100 text-slate-500",
+      valueClass: "text-slate-500",
+    };
+  }
+
+  return {
+    containerClass: detailFieldContainerToneClass[tone],
+    valueClass:
+      tone === "default" && accent
+        ? "text-primary"
+        : detailFieldValueToneClass[tone],
+  };
 }
 
 function SummaryEvent({

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -11,7 +11,10 @@ import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import PersonIcon from "@mui/icons-material/Person";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Button } from "@/components/ui/button";
-import { getAccessPoints, type AccessPointResponse } from "@/lib/api/accessPoints";
+import {
+  getAccessPoints,
+  type AccessPointResponse,
+} from "@/lib/api/accessPoints";
 import { ApiError } from "@/lib/apiClient";
 import {
   getKeycard,
@@ -97,7 +100,9 @@ export default function ReturnKeycardPage() {
   }
 
   if (error && !keycard) {
-    return <PageState title="Tagastusvaadet ei saanud avada" description={error} />;
+    return (
+      <PageState title="Tagastusvaadet ei saanud avada" description={error} />
+    );
   }
 
   if (isNotFound || !keycard) {
@@ -243,8 +248,7 @@ export default function ReturnKeycardPage() {
               <div className="flex items-start gap-2">
                 <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
                 <p>
-                  Swaggeri järgi vajab tagastus ainult välja
-                  {" "}
+                  Swaggeri järgi vajab tagastus ainult välja{" "}
                   <code>returnAccessPointId</code>. Tagastuse kellaaeg lisatakse
                   backendis automaatselt.
                 </p>
@@ -262,7 +266,9 @@ export default function ReturnKeycardPage() {
               <select
                 id="returnAccessPointId"
                 value={selectedAccessPointId}
-                onChange={(event) => setSelectedAccessPointId(event.target.value)}
+                onChange={(event) =>
+                  setSelectedAccessPointId(event.target.value)
+                }
                 className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-800 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/10"
                 disabled={isSubmitting || accessPoints.length === 0}
               >
@@ -347,7 +353,13 @@ function DetailField({
       <p className="text-[10px] font-black uppercase tracking-widest text-slate-400">
         {label}
       </p>
-      <p className={accent ? "text-sm font-semibold text-primary" : "text-sm font-semibold text-slate-900"}>
+      <p
+        className={
+          accent
+            ? "text-sm font-semibold text-primary"
+            : "text-sm font-semibold text-slate-900"
+        }
+      >
         {value}
       </p>
     </div>

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -244,17 +244,7 @@ export default function ReturnKeycardPage() {
           </div>
 
           <form className="space-y-5" onSubmit={handleSubmit}>
-            <div className="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-slate-700">
-              <div className="flex items-start gap-2">
-                <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
-                <p>
-                  Swaggeri järgi vajab tagastus ainult välja{" "}
-                  <code>returnAccessPointId</code>. Tagastuse kellaaeg lisatakse
-                  backendis automaatselt.
-                </p>
-              </div>
-            </div>
-
+            
             <div className="space-y-2">
               <label
                 htmlFor="returnAccessPointId"

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import AssignmentReturnIcon from "@mui/icons-material/AssignmentReturn";
+import CreditCardIcon from "@mui/icons-material/CreditCard";
+import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
+import PersonIcon from "@mui/icons-material/Person";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Button } from "@/components/ui/button";
+import { getAccessPoints, type AccessPointResponse } from "@/lib/api/accessPoints";
+import { ApiError } from "@/lib/apiClient";
+import {
+  getKeycard,
+  getKeycardStatusLabel,
+  returnKeycard,
+  type KeycardDetailResponse,
+} from "@/lib/api/keycards";
+
+export default function ReturnKeycardPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const keycardId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const [keycard, setKeycard] = useState<KeycardDetailResponse | null>(null);
+  const [accessPoints, setAccessPoints] = useState<AccessPointResponse[]>([]);
+  const [selectedAccessPointId, setSelectedAccessPointId] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isNotFound, setIsNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!keycardId) {
+      setIsLoading(false);
+      setIsNotFound(true);
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadData = async () => {
+      setIsLoading(true);
+      setError(null);
+      setIsNotFound(false);
+
+      try {
+        const [detail, points] = await Promise.all([
+          getKeycard(keycardId),
+          getAccessPoints(),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setKeycard(detail);
+        setAccessPoints(points);
+
+        if (points.length === 1) {
+          setSelectedAccessPointId(points[0].id);
+        }
+      } catch (err) {
+        if (!isMounted) {
+          return;
+        }
+
+        if (err instanceof ApiError && err.status === 404) {
+          setIsNotFound(true);
+          return;
+        }
+
+        setError(
+          err instanceof ApiError
+            ? err.message
+            : "Kaardi tagastuse ettevalmistamine ebaõnnestus.",
+        );
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [keycardId]);
+
+  if (isLoading) {
+    return <PageState title="Valmistan kaardi tagastust ette..." />;
+  }
+
+  if (error && !keycard) {
+    return <PageState title="Tagastusvaadet ei saanud avada" description={error} />;
+  }
+
+  if (isNotFound || !keycard) {
+    return (
+      <PageState
+        title="Võtmekaarti ei leitud"
+        description="Kontrolli, kas valitud kaart on süsteemis olemas või ava see nimekirjast uuesti."
+      />
+    );
+  }
+
+  const canReturnKeycard =
+    keycard.status === "in_use" &&
+    Boolean(keycard.assignedUser || keycard.assignedTime);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedAccessPointId) {
+      setError("Vali tagastamise vastuvõtupunkt.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await returnKeycard(keycard.id, {
+        returnAccessPointId: selectedAccessPointId,
+      });
+
+      router.replace(`/keys/${keycard.id}`);
+    } catch (err) {
+      setError(
+        err instanceof ApiError
+          ? err.message
+          : "Kaardi tagastamine ebaõnnestus.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!canReturnKeycard) {
+    return (
+      <PageState
+        title="Kaarti ei saa tagastada"
+        description="See kaart ei ole praegu välja antud, seega tagastust ei saa registreerida."
+        action={
+          <Button asChild variant="outline" className="mt-4 gap-2 rounded-xl">
+            <Link href={`/keys/${keycard.id}`}>
+              <ArrowBackIcon className="!text-base" />
+              Tagasi kaardi vaatesse
+            </Link>
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 animate-in fade-in duration-500">
+      <div className="space-y-4">
+        <nav className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
+          <Link href="/" className="transition-colors hover:text-primary">
+            Pääsla
+          </Link>
+          <ChevronRightIcon className="!text-sm" />
+          <Link href="/keys" className="transition-colors hover:text-primary">
+            Võtmekaardid
+          </Link>
+          <ChevronRightIcon className="!text-sm" />
+          <Link
+            href={`/keys/${keycard.id}`}
+            className="transition-colors hover:text-primary"
+          >
+            {keycard.keycardNumber}
+          </Link>
+          <ChevronRightIcon className="!text-sm" />
+          <span className="text-primary">Tagastus</span>
+        </nav>
+
+        <div className="flex flex-col justify-between gap-4 md:flex-row md:items-start">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <AssignmentReturnIcon className="!text-2xl text-primary" />
+              <h1 className="font-display text-3xl font-black tracking-tight text-slate-900">
+                Tagasta kiipkaart
+              </h1>
+            </div>
+            <p className="max-w-2xl text-slate-500">
+              Registreeri kaardi tagastus, valides vastuvõtupunkti. Backend
+              salvestab tagastuse aja automaatselt.
+            </p>
+          </div>
+
+          <Button asChild variant="outline" className="gap-2 rounded-xl">
+            <Link href={`/keys/${keycard.id}`}>
+              <ArrowBackIcon className="!text-base" />
+              Tagasi kaardi vaatesse
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-5 flex items-center gap-2">
+            <h2 className="flex items-center gap-2 text-sm font-black uppercase tracking-widest text-slate-500">
+              <CreditCardIcon className="!text-lg text-primary" />
+              Tagastatav kaart
+            </h2>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+            <DetailField label="Kaardi number" value={keycard.keycardNumber} />
+            <DetailField
+              label="Staatus"
+              value={getKeycardStatusLabel(keycard.status)}
+            />
+            <DetailField
+              label="Kaardi kasutaja"
+              value={keycard.assignedUser ?? "Aktiivne kasutaja puudub"}
+              accent={Boolean(keycard.assignedUser)}
+            />
+            <DetailField
+              label="Väljastamise aeg"
+              value={formatDateTime(keycard.assignedTime, "Puudub")}
+            />
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-5 flex items-center gap-2">
+            <h2 className="flex items-center gap-2 text-sm font-black uppercase tracking-widest text-slate-500">
+              <MeetingRoomIcon className="!text-lg text-primary" />
+              Tagastuse andmed
+            </h2>
+          </div>
+
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div className="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-slate-700">
+              <div className="flex items-start gap-2">
+                <InfoOutlinedIcon className="mt-0.5 !text-base text-blue-600" />
+                <p>
+                  Swaggeri järgi vajab tagastus ainult välja
+                  {" "}
+                  <code>returnAccessPointId</code>. Tagastuse kellaaeg lisatakse
+                  backendis automaatselt.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label
+                htmlFor="returnAccessPointId"
+                className="flex items-center gap-2 text-sm font-bold text-slate-700"
+              >
+                <PersonIcon className="!text-base text-slate-400" />
+                Vastuvõtupunkt
+              </label>
+              <select
+                id="returnAccessPointId"
+                value={selectedAccessPointId}
+                onChange={(event) => setSelectedAccessPointId(event.target.value)}
+                className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-800 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/10"
+                disabled={isSubmitting || accessPoints.length === 0}
+              >
+                <option value="">Vali vastuvõtupunkt</option>
+                {accessPoints.map((accessPoint) => (
+                  <option key={accessPoint.id} value={accessPoint.id}>
+                    {accessPoint.name}
+                  </option>
+                ))}
+              </select>
+              {accessPoints.length === 0 ? (
+                <p className="text-sm text-amber-700">
+                  Ühtegi vastuvõtupunkti ei leitud. Tagastust ei saa enne
+                  registreerida.
+                </p>
+              ) : null}
+            </div>
+
+            {error ? (
+              <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700">
+                {error}
+              </div>
+            ) : null}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Button asChild variant="outline" className="rounded-xl">
+                <Link href={`/keys/${keycard.id}`}>Loobu</Link>
+              </Button>
+              <Button
+                type="submit"
+                className="gap-2 rounded-xl px-5"
+                disabled={
+                  isSubmitting ||
+                  accessPoints.length === 0 ||
+                  !selectedAccessPointId
+                }
+              >
+                <AssignmentReturnIcon className="!text-base" />
+                {isSubmitting ? "Tagastan..." : "Kinnita tagastus"}
+              </Button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function PageState({
+  title,
+  description,
+  action,
+}: Readonly<{
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}>) {
+  return (
+    <div className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center">
+      <div className="rounded-3xl border border-slate-200 bg-white px-8 py-10 text-center shadow-sm">
+        <p className="text-lg font-bold text-slate-900">{title}</p>
+        {description ? (
+          <p className="mt-2 max-w-lg text-sm text-slate-500">{description}</p>
+        ) : null}
+        {action}
+      </div>
+    </div>
+  );
+}
+
+function DetailField({
+  label,
+  value,
+  accent = false,
+}: Readonly<{
+  label: string;
+  value: string;
+  accent?: boolean;
+}>) {
+  return (
+    <div className="space-y-1 rounded-2xl bg-slate-50 px-4 py-4">
+      <p className="text-[10px] font-black uppercase tracking-widest text-slate-400">
+        {label}
+      </p>
+      <p className={accent ? "text-sm font-semibold text-primary" : "text-sm font-semibold text-slate-900"}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function formatDateTime(value: string | null, emptyLabel: string): string {
+  if (!value) {
+    return emptyLabel;
+  }
+
+  return new Intl.DateTimeFormat("et-EE", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -244,7 +244,6 @@ export default function ReturnKeycardPage() {
           </div>
 
           <form className="space-y-5" onSubmit={handleSubmit}>
-            
             <div className="space-y-2">
               <label
                 htmlFor="returnAccessPointId"

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -190,7 +190,7 @@ export default function ReturnKeycardPage() {
             <div className="flex items-center gap-3">
               <AssignmentReturnIcon className="!text-2xl text-primary" />
               <h1 className="font-display text-3xl font-black tracking-tight text-slate-900">
-                Tagasta kiipkaart
+                Tagasta võtmekaart
               </h1>
             </div>
             <p className="max-w-2xl text-slate-500">

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -9,7 +9,6 @@ import AssignmentReturnIcon from "@mui/icons-material/AssignmentReturn";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
 import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import PersonIcon from "@mui/icons-material/Person";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Button } from "@/components/ui/button";
 import {
   getAccessPoints,

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -14,20 +14,33 @@ import InfoIcon from "@mui/icons-material/Info";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/apiClient";
 import {
+  getKeycard,
   getKeycards,
   getKeycardStatusLabel,
+  type KeycardStatus,
   type KeycardResponse,
 } from "@/lib/api/keycards";
+
+type StatusFilterValue = "all" | KeycardStatus;
+type DateSortOrder = "default" | "newest" | "oldest";
+type LastReturnFilterMode = "all" | "before" | "after" | "on";
 
 export default function KeycardsPage() {
   const [keycards, setKeycards] = useState<KeycardResponse[]>([]);
   const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("all");
+  const [issuedSort, setIssuedSort] = useState<DateSortOrder>("default");
+  const [lastReturnSort, setLastReturnSort] =
+    useState<DateSortOrder>("default");
+  const [lastReturnFilterMode, setLastReturnFilterMode] =
+    useState<LastReturnFilterMode>("all");
+  const [lastReturnDate, setLastReturnDate] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const deferredSearch = useDeferredValue(search.trim().toLowerCase());
 
-  const filteredKeycards = keycards.filter((keycard) => {
+  const searchFilteredKeycards = keycards.filter((keycard) => {
     if (!deferredSearch) return true;
 
     const haystack = [
@@ -40,6 +53,24 @@ export default function KeycardsPage() {
 
     return haystack.includes(deferredSearch);
   });
+
+  const statusFilteredKeycards = searchFilteredKeycards.filter((keycard) =>
+    statusFilter === "all" ? true : keycard.status === statusFilter,
+  );
+
+  const lastReturnFilteredKeycards = statusFilteredKeycards.filter((keycard) =>
+    matchesLastReturnFilter(
+      keycard.lastReturnTime,
+      lastReturnFilterMode,
+      lastReturnDate,
+    ),
+  );
+
+  const filteredKeycards = sortKeycards(
+    lastReturnFilteredKeycards,
+    issuedSort,
+    lastReturnSort,
+  );
 
   const summary = keycards.reduce(
     (accumulator, keycard) => {
@@ -72,7 +103,36 @@ export default function KeycardsPage() {
       try {
         const page = await getKeycards({ size: 200 });
         if (!isMounted) return;
-        setKeycards(page.content);
+
+        const inUseWithoutAssignedTime = page.content.filter(
+          (keycard) => keycard.status === "in_use" && !keycard.assignedTime,
+        );
+
+        if (inUseWithoutAssignedTime.length === 0) {
+          setKeycards(page.content);
+          return;
+        }
+
+        const detailedResults = await Promise.allSettled(
+          inUseWithoutAssignedTime.map((keycard) => getKeycard(keycard.id)),
+        );
+
+        if (!isMounted) return;
+
+        const detailsById = new Map(
+          detailedResults.flatMap((result) =>
+            result.status === "fulfilled"
+              ? [[result.value.id, result.value] as const]
+              : [],
+          ),
+        );
+
+        setKeycards(
+          page.content.map((keycard) => {
+            const detail = detailsById.get(keycard.id);
+            return detail ? { ...keycard, ...detail } : keycard;
+          }),
+        );
       } catch (err) {
         if (!isMounted) return;
         setError(
@@ -162,6 +222,72 @@ export default function KeycardsPage() {
             placeholder="Otsi kaardi numbri või kasutaja järgi..."
           />
         </div>
+        <FilterField label="Staatus">
+          <select
+            value={statusFilter}
+            onChange={(event) =>
+              setStatusFilter(event.target.value as StatusFilterValue)
+            }
+            className={filterInputCls}
+          >
+            <option value="all">Kõik staatused</option>
+            <option value="available">Saadaval</option>
+            <option value="in_use">Kasutuses</option>
+            <option value="disabled">Deaktiveeritud</option>
+            <option value="expired">Aegunud</option>
+          </select>
+        </FilterField>
+        <FilterField label="Väljastatud">
+          <select
+            value={issuedSort}
+            onChange={(event) =>
+              setIssuedSort(event.target.value as DateSortOrder)
+            }
+            className={filterInputCls}
+          >
+            <option value="default">Vaikimisi</option>
+            <option value="newest">Uuem enne</option>
+            <option value="oldest">Vanem enne</option>
+          </select>
+        </FilterField>
+        <FilterField label="Viimati tagastatud">
+          <select
+            value={lastReturnSort}
+            onChange={(event) =>
+              setLastReturnSort(event.target.value as DateSortOrder)
+            }
+            className={filterInputCls}
+          >
+            <option value="default">Vaikimisi</option>
+            <option value="newest">Uuem enne</option>
+            <option value="oldest">Vanem enne</option>
+          </select>
+        </FilterField>
+        <FilterField label="Tagastuse kuupäev">
+          <div className="flex min-w-[260px] gap-2">
+            <select
+              value={lastReturnFilterMode}
+              onChange={(event) =>
+                setLastReturnFilterMode(
+                  event.target.value as LastReturnFilterMode,
+                )
+              }
+              className={filterInputCls + " min-w-[120px]"}
+            >
+              <option value="all">Kõik</option>
+              <option value="before">Enne</option>
+              <option value="after">Pärast</option>
+              <option value="on">Täpselt</option>
+            </select>
+            <input
+              type="date"
+              value={lastReturnDate}
+              onChange={(event) => setLastReturnDate(event.target.value)}
+              disabled={lastReturnFilterMode === "all"}
+              className={filterInputCls + " min-w-[140px]"}
+            />
+          </div>
+        </FilterField>
         <Button
           variant="outline"
           size="icon"
@@ -385,4 +511,108 @@ function StatSmall({
       </div>
     </div>
   );
+}
+
+function FilterField({
+  label,
+  children,
+}: Readonly<{
+  label: string;
+  children: ReactNode;
+}>) {
+  return (
+    <label className="space-y-1">
+      <span className="block text-[10px] font-black uppercase tracking-widest text-slate-400">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const filterInputCls =
+  "h-10 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm font-semibold text-slate-700 outline-none transition-colors focus:border-primary/40 focus:bg-white disabled:cursor-not-allowed disabled:opacity-60";
+
+function sortKeycards(
+  keycards: KeycardResponse[],
+  issuedSort: DateSortOrder,
+  lastReturnSort: DateSortOrder,
+) {
+  if (issuedSort === "default" && lastReturnSort === "default") {
+    return keycards;
+  }
+
+  return [...keycards].sort((left, right) => {
+    const issuedComparison = compareNullableDate(
+      left.assignedTime,
+      right.assignedTime,
+      issuedSort,
+    );
+
+    if (issuedComparison !== 0) {
+      return issuedComparison;
+    }
+
+    return compareNullableDate(
+      left.lastReturnTime,
+      right.lastReturnTime,
+      lastReturnSort,
+    );
+  });
+}
+
+function compareNullableDate(
+  left: string | null,
+  right: string | null,
+  order: DateSortOrder,
+) {
+  if (order === "default") {
+    return 0;
+  }
+
+  if (!left && !right) {
+    return 0;
+  }
+
+  if (!left) {
+    return 1;
+  }
+
+  if (!right) {
+    return -1;
+  }
+
+  const leftTime = new Date(left).getTime();
+  const rightTime = new Date(right).getTime();
+
+  return order === "newest" ? rightTime - leftTime : leftTime - rightTime;
+}
+
+function matchesLastReturnFilter(
+  value: string | null,
+  mode: LastReturnFilterMode,
+  date: string,
+) {
+  if (mode === "all" || !date) {
+    return true;
+  }
+
+  if (!value) {
+    return false;
+  }
+
+  const entryTime = new Date(value).getTime();
+  const startOfSelectedDay = new Date(`${date}T00:00:00`).getTime();
+  const endOfSelectedDay = new Date(`${date}T23:59:59.999`).getTime();
+
+  switch (mode) {
+    case "before":
+      return entryTime < startOfSelectedDay;
+    case "after":
+      return entryTime > endOfSelectedDay;
+    case "on":
+      return entryTime >= startOfSelectedDay && entryTime <= endOfSelectedDay;
+    case "all":
+      return true;
+  }
 }

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -95,6 +95,26 @@ export default function KeycardsPage() {
     };
   }, []);
 
+  let tableBodyContent: ReactNode;
+
+  if (isLoading) {
+    tableBodyContent = <LoadingRow />;
+  } else if (filteredKeycards.length > 0) {
+    tableBodyContent = filteredKeycards.map((keycard) => (
+      <KeycardRow key={keycard.id} keycard={keycard} />
+    ));
+  } else {
+    tableBodyContent = (
+      <EmptyRow
+        title={error ? "Võtmekaartide laadimine ebaõnnestus" : "Tulemusi ei leitud"}
+        description={
+          error ??
+          "Muuda otsingut või kontrolli, kas võtmekaardid on süsteemis olemas."
+        }
+      />
+    );
+  }
+
   return (
     <div className="mx-auto max-w-7xl space-y-8 animate-in fade-in duration-500">
       <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
@@ -146,7 +166,7 @@ export default function KeycardsPage() {
           size="icon"
           className="rounded-xl text-slate-500"
           aria-label="Värskenda võtmekaarte"
-          onClick={() => window.location.reload()}
+          onClick={() => globalThis.location.reload()}
         >
           <RefreshIcon />
         </Button>
@@ -165,27 +185,7 @@ export default function KeycardsPage() {
                 <th className="px-6 py-5 text-right">Tegevus</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
-              {isLoading ? (
-                <LoadingRow />
-              ) : filteredKeycards.length > 0 ? (
-                filteredKeycards.map((keycard) => (
-                  <KeycardRow key={keycard.id} keycard={keycard} />
-                ))
-              ) : (
-                <EmptyRow
-                  title={
-                    error
-                      ? "Võtmekaartide laadimine ebaõnnestus"
-                      : "Tulemusi ei leitud"
-                  }
-                  description={
-                    error ??
-                    "Muuda otsingut või kontrolli, kas võtmekaardid on süsteemis olemas."
-                  }
-                />
-              )}
-            </tbody>
+            <tbody className="divide-y divide-slate-100">{tableBodyContent}</tbody>
           </table>
         </div>
 

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -11,6 +11,7 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
 import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import InfoIcon from "@mui/icons-material/Info";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/apiClient";
 import {
@@ -22,16 +23,23 @@ import {
 } from "@/lib/api/keycards";
 
 type StatusFilterValue = "all" | KeycardStatus;
-type DateSortOrder = "default" | "newest" | "oldest";
+type SortDirection = "default" | "asc" | "desc";
 type LastReturnFilterMode = "all" | "before" | "after" | "on";
+type HeaderSortKey = "number" | "status" | "user" | "issued" | "returned";
 
 export default function KeycardsPage() {
   const [keycards, setKeycards] = useState<KeycardResponse[]>([]);
   const [search, setSearch] = useState("");
+  const [numberSort, setNumberSort] = useState<SortDirection>("default");
   const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("all");
-  const [issuedSort, setIssuedSort] = useState<DateSortOrder>("default");
+  const [statusSort, setStatusSort] = useState<SortDirection>("default");
+  const [userSort, setUserSort] = useState<SortDirection>("default");
+  const [issuedSort, setIssuedSort] = useState<SortDirection>("default");
+  const [headerSortPriority, setHeaderSortPriority] = useState<HeaderSortKey[]>(
+    ["number", "status", "user", "issued", "returned"],
+  );
   const [lastReturnSort, setLastReturnSort] =
-    useState<DateSortOrder>("default");
+    useState<SortDirection>("default");
   const [lastReturnFilterMode, setLastReturnFilterMode] =
     useState<LastReturnFilterMode>("all");
   const [lastReturnDate, setLastReturnDate] = useState("");
@@ -68,7 +76,11 @@ export default function KeycardsPage() {
 
   const filteredKeycards = sortKeycards(
     lastReturnFilteredKeycards,
+    numberSort,
+    statusSort,
+    userSort,
     issuedSort,
+    headerSortPriority,
     lastReturnSort,
   );
 
@@ -237,30 +249,17 @@ export default function KeycardsPage() {
             <option value="expired">Aegunud</option>
           </select>
         </FilterField>
-        <FilterField label="Väljastatud">
-          <select
-            value={issuedSort}
-            onChange={(event) =>
-              setIssuedSort(event.target.value as DateSortOrder)
-            }
-            className={filterInputCls}
-          >
-            <option value="default">Vaikimisi</option>
-            <option value="newest">Uuem enne</option>
-            <option value="oldest">Vanem enne</option>
-          </select>
-        </FilterField>
         <FilterField label="Viimati tagastatud">
           <select
             value={lastReturnSort}
             onChange={(event) =>
-              setLastReturnSort(event.target.value as DateSortOrder)
+              setLastReturnSort(event.target.value as SortDirection)
             }
             className={filterInputCls}
           >
             <option value="default">Vaikimisi</option>
-            <option value="newest">Uuem enne</option>
-            <option value="oldest">Vanem enne</option>
+            <option value="desc">Uuem enne</option>
+            <option value="asc">Vanem enne</option>
           </select>
         </FilterField>
         <FilterField label="Tagastuse kuupäev">
@@ -304,11 +303,73 @@ export default function KeycardsPage() {
           <table className="w-full border-collapse text-left">
             <thead className="border-b border-slate-100 bg-slate-50/80 text-[10px] font-black uppercase tracking-[0.15em] text-slate-400">
               <tr>
-                <th className="px-6 py-5">Kaardi number</th>
-                <th className="px-6 py-5">Staatus</th>
-                <th className="px-6 py-5">Kasutaja</th>
-                <th className="px-6 py-5">Väljastatud</th>
-                <th className="px-6 py-5">Viimati tagastatud</th>
+                <th className="px-6 py-5">
+                  <SortableHeader
+                    label="Kaardi number"
+                    direction={numberSort}
+                    onClick={() => {
+                      setNumberSort((current) => getNextSortDirection(current));
+                      setHeaderSortPriority((current) => [
+                        "number",
+                        ...current.filter((key) => key !== "number"),
+                      ]);
+                    }}
+                  />
+                </th>
+                <th className="px-6 py-5">
+                  <SortableHeader
+                    label="Staatus"
+                    direction={statusSort}
+                    onClick={() => {
+                      setStatusSort((current) => getNextSortDirection(current));
+                      setHeaderSortPriority((current) => [
+                        "status",
+                        ...current.filter((key) => key !== "status"),
+                      ]);
+                    }}
+                  />
+                </th>
+                <th className="px-6 py-5">
+                  <SortableHeader
+                    label="Kasutaja"
+                    direction={userSort}
+                    onClick={() => {
+                      setUserSort((current) => getNextSortDirection(current));
+                      setHeaderSortPriority((current) => [
+                        "user",
+                        ...current.filter((key) => key !== "user"),
+                      ]);
+                    }}
+                  />
+                </th>
+                <th className="px-6 py-5">
+                  <SortableHeader
+                    label="Väljastatud"
+                    direction={issuedSort}
+                    onClick={() => {
+                      setIssuedSort((current) => getNextSortDirection(current));
+                      setHeaderSortPriority((current) => [
+                        "issued",
+                        ...current.filter((key) => key !== "issued"),
+                      ]);
+                    }}
+                  />
+                </th>
+                <th className="px-6 py-5">
+                  <SortableHeader
+                    label="Viimati tagastatud"
+                    direction={lastReturnSort}
+                    onClick={() => {
+                      setLastReturnSort((current) =>
+                        getNextSortDirection(current),
+                      );
+                      setHeaderSortPriority((current) => [
+                        "returned",
+                        ...current.filter((key) => key !== "returned"),
+                      ]);
+                    }}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
@@ -533,38 +594,110 @@ function FilterField({
 const filterInputCls =
   "h-10 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm font-semibold text-slate-700 outline-none transition-colors focus:border-primary/40 focus:bg-white disabled:cursor-not-allowed disabled:opacity-60";
 
+function SortableHeader({
+  label,
+  direction,
+  onClick,
+}: Readonly<{
+  label: string;
+  direction: SortDirection;
+  onClick: () => void;
+}>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-full w-full items-center justify-between gap-2 text-left select-none transition-colors hover:text-slate-600"
+    >
+      <span>{label}</span>
+      {direction === "asc" ? (
+        <ChevronDownIcon size={16} className="shrink-0 opacity-60" />
+      ) : direction === "desc" ? (
+        <ChevronUpIcon size={16} className="shrink-0 opacity-60" />
+      ) : null}
+    </button>
+  );
+}
+
 function sortKeycards(
   keycards: KeycardResponse[],
-  issuedSort: DateSortOrder,
-  lastReturnSort: DateSortOrder,
+  numberSort: SortDirection,
+  statusSort: SortDirection,
+  userSort: SortDirection,
+  issuedSort: SortDirection,
+  headerSortPriority: HeaderSortKey[],
+  lastReturnSort: SortDirection,
 ) {
-  if (issuedSort === "default" && lastReturnSort === "default") {
+  if (
+    numberSort === "default" &&
+    statusSort === "default" &&
+    userSort === "default" &&
+    issuedSort === "default" &&
+    lastReturnSort === "default"
+  ) {
     return keycards;
   }
 
   return [...keycards].sort((left, right) => {
-    const issuedComparison = compareNullableDate(
-      left.assignedTime,
-      right.assignedTime,
-      issuedSort,
-    );
+    for (const key of headerSortPriority) {
+      const comparison =
+        key === "number"
+          ? compareNullableText(
+              left.keycardNumber,
+              right.keycardNumber,
+              numberSort,
+            )
+          : key === "status"
+            ? compareStatus(left.status, right.status, statusSort)
+            : key === "user"
+              ? compareNullableText(
+                  left.assignedUser,
+                  right.assignedUser,
+                  userSort,
+                )
+              : key === "issued"
+                ? compareNullableDate(
+                    left.assignedTime,
+                    right.assignedTime,
+                    issuedSort,
+                  )
+                : compareNullableDate(
+                    left.lastReturnTime,
+                    right.lastReturnTime,
+                    lastReturnSort,
+                  );
 
-    if (issuedComparison !== 0) {
-      return issuedComparison;
+      if (comparison !== 0) {
+        return comparison;
+      }
     }
 
-    return compareNullableDate(
-      left.lastReturnTime,
-      right.lastReturnTime,
-      lastReturnSort,
-    );
+    return 0;
   });
+}
+
+function compareStatus(
+  left: KeycardStatus,
+  right: KeycardStatus,
+  order: SortDirection,
+) {
+  if (order === "default") {
+    return 0;
+  }
+
+  const comparison = getKeycardStatusLabel(left).localeCompare(
+    getKeycardStatusLabel(right),
+    "et",
+    { sensitivity: "base" },
+  );
+
+  return order === "desc" ? -comparison : comparison;
 }
 
 function compareNullableDate(
   left: string | null,
   right: string | null,
-  order: DateSortOrder,
+  order: SortDirection,
 ) {
   if (order === "default") {
     return 0;
@@ -585,7 +718,46 @@ function compareNullableDate(
   const leftTime = new Date(left).getTime();
   const rightTime = new Date(right).getTime();
 
-  return order === "newest" ? rightTime - leftTime : leftTime - rightTime;
+  return order === "desc" ? rightTime - leftTime : leftTime - rightTime;
+}
+
+function compareNullableText(
+  left: string | null,
+  right: string | null,
+  order: SortDirection,
+) {
+  if (order === "default") {
+    return 0;
+  }
+
+  if (!left && !right) {
+    return 0;
+  }
+
+  if (!left) {
+    return 1;
+  }
+
+  if (!right) {
+    return -1;
+  }
+
+  const comparison = left.localeCompare(right, "et", {
+    sensitivity: "base",
+  });
+
+  return order === "desc" ? -comparison : comparison;
+}
+
+function getNextSortDirection(direction: SortDirection): SortDirection {
+  switch (direction) {
+    case "default":
+      return "asc";
+    case "asc":
+      return "desc";
+    case "desc":
+      return "default";
+  }
 }
 
 function matchesLastReturnFilter(

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -451,8 +451,9 @@ export default function KeycardsPage() {
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3 md:justify-end">
             <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
-              Leht <span className="text-slate-900">{visiblePageIndex + 1}</span>{" "}
-              / <span className="text-slate-900">{totalPages}</span>
+              Leht{" "}
+              <span className="text-slate-900">{visiblePageIndex + 1}</span> /{" "}
+              <span className="text-slate-900">{totalPages}</span>
             </p>
             <div className="flex items-center gap-2">
               <Button
@@ -460,7 +461,9 @@ export default function KeycardsPage() {
                 variant="outline"
                 size="icon"
                 className="rounded-xl text-slate-500"
-                onClick={() => setPageIndex((current) => Math.max(0, current - 1))}
+                onClick={() =>
+                  setPageIndex((current) => Math.max(0, current - 1))
+                }
                 disabled={visiblePageIndex === 0}
                 aria-label="Eelmine leht"
               >
@@ -472,7 +475,9 @@ export default function KeycardsPage() {
                 size="icon"
                 className="rounded-xl text-slate-500"
                 onClick={() =>
-                  setPageIndex((current) => Math.min(totalPages - 1, current + 1))
+                  setPageIndex((current) =>
+                    Math.min(totalPages - 1, current + 1),
+                  )
                 }
                 disabled={visiblePageIndex >= totalPages - 1}
                 aria-label="Järgmine leht"

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { type ReactNode, useDeferredValue, useEffect, useState } from "react";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
@@ -30,6 +31,8 @@ type HeaderSortKey = "number" | "status" | "user" | "issued" | "returned";
 export default function KeycardsPage() {
   const [keycards, setKeycards] = useState<KeycardResponse[]>([]);
   const [search, setSearch] = useState("");
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
   const [numberSort, setNumberSort] = useState<SortDirection>("default");
   const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("all");
   const [statusSort, setStatusSort] = useState<SortDirection>("default");
@@ -83,6 +86,21 @@ export default function KeycardsPage() {
     headerSortPriority,
     lastReturnSort,
   );
+
+  const totalFilteredKeycards = filteredKeycards.length;
+  const totalPages = Math.max(1, Math.ceil(totalFilteredKeycards / pageSize));
+  const visiblePageIndex = Math.min(pageIndex, totalPages - 1);
+  const pageStart = visiblePageIndex * pageSize;
+  const paginatedKeycards = filteredKeycards.slice(
+    pageStart,
+    pageStart + pageSize,
+  );
+  const visibleRangeStart =
+    totalFilteredKeycards === 0 ? 0 : visiblePageIndex * pageSize + 1;
+  const visibleRangeEnd =
+    totalFilteredKeycards === 0
+      ? 0
+      : Math.min(visiblePageIndex * pageSize + pageSize, totalFilteredKeycards);
 
   const summary = keycards.reduce(
     (accumulator, keycard) => {
@@ -166,12 +184,33 @@ export default function KeycardsPage() {
     };
   }, []);
 
+  useEffect(() => {
+    setPageIndex(0);
+  }, [
+    deferredSearch,
+    statusFilter,
+    numberSort,
+    statusSort,
+    userSort,
+    issuedSort,
+    lastReturnSort,
+    lastReturnFilterMode,
+    lastReturnDate,
+    headerSortPriority,
+  ]);
+
+  useEffect(() => {
+    if (pageIndex > totalPages - 1) {
+      setPageIndex(Math.max(0, totalPages - 1));
+    }
+  }, [pageIndex, totalPages]);
+
   let tableBodyContent: ReactNode;
 
   if (isLoading) {
     tableBodyContent = <LoadingRow />;
-  } else if (filteredKeycards.length > 0) {
-    tableBodyContent = filteredKeycards.map((keycard) => (
+  } else if (paginatedKeycards.length > 0) {
+    tableBodyContent = paginatedKeycards.map((keycard) => (
       <KeycardRow key={keycard.id} keycard={keycard} />
     ));
   } else {
@@ -233,6 +272,9 @@ export default function KeycardsPage() {
             className="w-full rounded-xl bg-slate-50 py-2.5 pr-4 pl-10 text-sm font-semibold text-slate-700 placeholder:text-slate-300"
             placeholder="Otsi kaardi numbri või kasutaja järgi..."
           />
+        </div>
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-slate-500">
+          <FilterListIcon className="!text-lg" />
         </div>
         <FilterField label="Staatus">
           <select
@@ -301,7 +343,7 @@ export default function KeycardsPage() {
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-left">
-            <thead className="border-b border-slate-100 bg-slate-50/80 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
+            <thead className="border-b border-slate-100 bg-slate-50/80 text-sm font-medium text-slate-500">
               <tr>
                 <th className="px-6 py-5">
                   <SortableHeader
@@ -378,15 +420,67 @@ export default function KeycardsPage() {
           </table>
         </div>
 
-        <div className="flex items-center justify-between border-t border-slate-100 bg-slate-50/60 px-6 py-4">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
-            Näitan{" "}
-            <span className="text-slate-900">{filteredKeycards.length}</span> /{" "}
-            <span className="text-slate-900">{keycards.length}</span> kaardist
-          </p>
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
-            Ava detailvaade, et näha määramist ja kaardi olekut
-          </p>
+        <div className="flex flex-col gap-3 border-t border-slate-100 bg-slate-50/60 px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-slate-400">
+              <span>Ridu lehel</span>
+              <select
+                value={pageSize}
+                onChange={(event) => setPageSize(Number(event.target.value))}
+                className="h-9 rounded-xl border border-slate-200 bg-white px-3 text-xs font-bold text-slate-700 outline-none transition-colors focus:border-primary/40"
+              >
+                <option value={5}>5</option>
+                <option value={10}>10</option>
+                <option value={25}>25</option>
+                <option value={50}>50</option>
+              </select>
+            </label>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+              Näitan <span className="text-slate-900">{visibleRangeStart}</span>
+              {" - "}
+              <span className="text-slate-900">{visibleRangeEnd}</span> /{" "}
+              <span className="text-slate-900">{totalFilteredKeycards}</span>
+              {keycards.length !== totalFilteredKeycards ? (
+                <>
+                  {" "}
+                  filtreeritud, kokku{" "}
+                  <span className="text-slate-900">{keycards.length}</span>
+                </>
+              ) : null}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 md:justify-end">
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+              Leht <span className="text-slate-900">{visiblePageIndex + 1}</span>{" "}
+              / <span className="text-slate-900">{totalPages}</span>
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="rounded-xl text-slate-500"
+                onClick={() => setPageIndex((current) => Math.max(0, current - 1))}
+                disabled={visiblePageIndex === 0}
+                aria-label="Eelmine leht"
+              >
+                <ChevronLeftIcon className="!text-lg" />
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="rounded-xl text-slate-500"
+                onClick={() =>
+                  setPageIndex((current) => Math.min(totalPages - 1, current + 1))
+                }
+                disabled={visiblePageIndex >= totalPages - 1}
+                aria-label="Järgmine leht"
+              >
+                <ChevronRightIcon className="!text-lg" />
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -607,7 +701,7 @@ function SortableHeader({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-full w-full items-center justify-between gap-2 text-left font-black uppercase select-none transition-colors hover:text-slate-600"
+      className="flex h-full w-full cursor-pointer items-center justify-between gap-2 text-left select-none transition-colors hover:text-slate-700"
     >
       <span>{label}</span>
       {direction === "asc" ? (

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -106,7 +106,9 @@ export default function KeycardsPage() {
   } else {
     tableBodyContent = (
       <EmptyRow
-        title={error ? "Võtmekaartide laadimine ebaõnnestus" : "Tulemusi ei leitud"}
+        title={
+          error ? "Võtmekaartide laadimine ebaõnnestus" : "Tulemusi ei leitud"
+        }
         description={
           error ??
           "Muuda otsingut või kontrolli, kas võtmekaardid on süsteemis olemas."
@@ -185,7 +187,9 @@ export default function KeycardsPage() {
                 <th className="px-6 py-5 text-right">Tegevus</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">{tableBodyContent}</tbody>
+            <tbody className="divide-y divide-slate-100">
+              {tableBodyContent}
+            </tbody>
           </table>
         </div>
 

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -101,6 +101,7 @@ export default function KeycardsPage() {
     totalFilteredKeycards === 0
       ? 0
       : Math.min(visiblePageIndex * pageSize + pageSize, totalFilteredKeycards);
+  const isFilteredResult = totalFilteredKeycards < keycards.length;
 
   const summary = keycards.reduce(
     (accumulator, keycard) => {
@@ -440,7 +441,7 @@ export default function KeycardsPage() {
               {" - "}
               <span className="text-slate-900">{visibleRangeEnd}</span> /{" "}
               <span className="text-slate-900">{totalFilteredKeycards}</span>
-              {keycards.length !== totalFilteredKeycards ? (
+              {isFilteredResult ? (
                 <>
                   {" "}
                   filtreeritud, kokku{" "}
@@ -702,6 +703,8 @@ function SortableHeader({
   direction: SortDirection;
   onClick: () => void;
 }>) {
+  const sortIcon = getSortIcon(direction);
+
   return (
     <button
       type="button"
@@ -709,13 +712,20 @@ function SortableHeader({
       className="flex h-full w-full cursor-pointer items-center justify-between gap-2 text-left select-none transition-colors hover:text-slate-700"
     >
       <span>{label}</span>
-      {direction === "asc" ? (
-        <ChevronDownIcon size={16} className="shrink-0 opacity-60" />
-      ) : direction === "desc" ? (
-        <ChevronUpIcon size={16} className="shrink-0 opacity-60" />
-      ) : null}
+      {sortIcon}
     </button>
   );
+}
+
+function getSortIcon(direction: SortDirection) {
+  switch (direction) {
+    case "asc":
+      return <ChevronDownIcon size={16} className="shrink-0 opacity-60" />;
+    case "desc":
+      return <ChevronUpIcon size={16} className="shrink-0 opacity-60" />;
+    case "default":
+      return null;
+  }
 }
 
 function sortKeycards(
@@ -739,32 +749,16 @@ function sortKeycards(
 
   return [...keycards].sort((left, right) => {
     for (const key of headerSortPriority) {
-      const comparison =
-        key === "number"
-          ? compareNullableText(
-              left.keycardNumber,
-              right.keycardNumber,
-              numberSort,
-            )
-          : key === "status"
-            ? compareStatus(left.status, right.status, statusSort)
-            : key === "user"
-              ? compareNullableText(
-                  left.assignedUser,
-                  right.assignedUser,
-                  userSort,
-                )
-              : key === "issued"
-                ? compareNullableDate(
-                    left.assignedTime,
-                    right.assignedTime,
-                    issuedSort,
-                  )
-                : compareNullableDate(
-                    left.lastReturnTime,
-                    right.lastReturnTime,
-                    lastReturnSort,
-                  );
+      const comparison = getKeycardComparison({
+        key,
+        left,
+        right,
+        numberSort,
+        statusSort,
+        userSort,
+        issuedSort,
+        lastReturnSort,
+      });
 
       if (comparison !== 0) {
         return comparison;
@@ -773,6 +767,55 @@ function sortKeycards(
 
     return 0;
   });
+}
+
+function getKeycardComparison({
+  key,
+  left,
+  right,
+  numberSort,
+  statusSort,
+  userSort,
+  issuedSort,
+  lastReturnSort,
+}: Readonly<{
+  key: HeaderSortKey;
+  left: KeycardResponse;
+  right: KeycardResponse;
+  numberSort: SortDirection;
+  statusSort: SortDirection;
+  userSort: SortDirection;
+  issuedSort: SortDirection;
+  lastReturnSort: SortDirection;
+}>) {
+  switch (key) {
+    case "number":
+      return compareNullableText(
+        left.keycardNumber,
+        right.keycardNumber,
+        numberSort,
+      );
+    case "status":
+      return compareStatus(left.status, right.status, statusSort);
+    case "user":
+      return compareNullableText(
+        left.assignedUser,
+        right.assignedUser,
+        userSort,
+      );
+    case "issued":
+      return compareNullableDate(
+        left.assignedTime,
+        right.assignedTime,
+        issuedSort,
+      );
+    case "returned":
+      return compareNullableDate(
+        left.lastReturnTime,
+        right.lastReturnTime,
+        lastReturnSort,
+      );
+  }
 }
 
 function compareStatus(
@@ -883,7 +926,5 @@ function matchesLastReturnFilter(
       return entryTime > endOfSelectedDay;
     case "on":
       return entryTime >= startOfSelectedDay && entryTime <= endOfSelectedDay;
-    case "all":
-      return true;
   }
 }

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -175,7 +175,9 @@ export default function KeycardsPage() {
               ) : (
                 <EmptyRow
                   title={
-                    error ? "Võtmekaartide laadimine ebaõnnestus" : "Tulemusi ei leitud"
+                    error
+                      ? "Võtmekaartide laadimine ebaõnnestus"
+                      : "Tulemusi ei leitud"
                   }
                   description={
                     error ??
@@ -189,8 +191,9 @@ export default function KeycardsPage() {
 
         <div className="flex items-center justify-between border-t border-slate-100 bg-slate-50/60 px-6 py-4">
           <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
-            Näitan <span className="text-slate-900">{filteredKeycards.length}</span>{" "}
-            / <span className="text-slate-900">{keycards.length}</span> kaardist
+            Näitan{" "}
+            <span className="text-slate-900">{filteredKeycards.length}</span> /{" "}
+            <span className="text-slate-900">{keycards.length}</span> kaardist
           </p>
           <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
             Ava detailvaade, et näha määramist ja kaardi olekut
@@ -264,7 +267,10 @@ function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
         )}
       </td>
       <td className="px-6 py-4">
-        <DateTimeStack value={keycard.assignedTime} emptyLabel="Pole väljastatud" />
+        <DateTimeStack
+          value={keycard.assignedTime}
+          emptyLabel="Pole väljastatud"
+        />
       </td>
       <td className="px-6 py-4">
         <DateTimeStack

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { type ReactNode, useDeferredValue, useEffect, useState } from "react";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
 import FilterListIcon from "@mui/icons-material/FilterList";
@@ -237,26 +236,15 @@ export default function KeycardsPage() {
 }
 
 function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
-  const router = useRouter();
   const href = `/keys/${keycard.id}`;
+  const label = `Ava võtmekaart ${keycard.keycardNumber}`;
 
   return (
-    <tr
-      tabIndex={0}
-      role="link"
-      aria-label={`Ava võtmekaart ${keycard.keycardNumber}`}
-      className="cursor-pointer transition-colors hover:bg-slate-50/70 focus-visible:bg-slate-50/70 focus-visible:outline-2 focus-visible:outline-primary/40"
-      onClick={() => router.push(href)}
-      onKeyDown={(event) => {
-        if (event.key !== "Enter" && event.key !== " ") {
-          return;
-        }
-
-        event.preventDefault();
-        router.push(href);
-      }}
-    >
-      <td className="px-6 py-4 whitespace-nowrap">
+    <tr className="cursor-pointer transition-colors hover:bg-slate-50/70 focus-within:bg-slate-50/70 focus-within:outline-2 focus-within:outline-primary/40">
+      <td className="relative px-6 py-4 whitespace-nowrap">
+        <Link href={href} className="absolute inset-0 z-10" aria-label={label}>
+          <span className="sr-only">{label}</span>
+        </Link>
         <div className="flex items-center gap-3">
           <div className="flex size-8 items-center justify-center rounded-lg bg-slate-100 text-slate-400">
             <CreditCardIcon className="!text-lg" />
@@ -271,10 +259,12 @@ function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
           </div>
         </div>
       </td>
-      <td className="px-6 py-4">
+      <td className="relative px-6 py-4">
+        <Link href={href} className="absolute inset-0 z-10" tabIndex={-1} />
         <StatusBadge status={keycard.status} />
       </td>
-      <td className="px-6 py-4">
+      <td className="relative px-6 py-4">
+        <Link href={href} className="absolute inset-0 z-10" tabIndex={-1} />
         {keycard.assignedUser ? (
           <p className="text-sm font-semibold text-slate-900">
             {keycard.assignedUser}
@@ -283,13 +273,15 @@ function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
           <p className="text-sm text-slate-400">Määramata</p>
         )}
       </td>
-      <td className="px-6 py-4">
+      <td className="relative px-6 py-4">
+        <Link href={href} className="absolute inset-0 z-10" tabIndex={-1} />
         <DateTimeStack
           value={keycard.assignedTime}
           emptyLabel="Pole väljastatud"
         />
       </td>
-      <td className="px-6 py-4">
+      <td className="relative px-6 py-4">
+        <Link href={href} className="absolute inset-0 z-10" tabIndex={-1} />
         <DateTimeStack
           value={keycard.lastReturnTime}
           emptyLabel="Tagastus puudub"

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -1,292 +1,355 @@
+"use client";
+
 import Link from "next/link";
+import { type ReactNode, useDeferredValue, useEffect, useState } from "react";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
-import SecurityIcon from "@mui/icons-material/Security";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import AddIcon from "@mui/icons-material/Add";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
+import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import InfoIcon from "@mui/icons-material/Info";
-import WarningIcon from "@mui/icons-material/Warning";
-import GppMaybeIcon from "@mui/icons-material/GppMaybe";
-import FirstPageIcon from "@mui/icons-material/FirstPage";
-import LastPageIcon from "@mui/icons-material/LastPage";
-import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/apiClient";
+import {
+  getKeycards,
+  getKeycardStatusLabel,
+  type KeycardResponse,
+} from "@/lib/api/keycards";
 
 export default function KeycardsPage() {
+  const [keycards, setKeycards] = useState<KeycardResponse[]>([]);
+  const [search, setSearch] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+
+  const filteredKeycards = keycards.filter((keycard) => {
+    if (!deferredSearch) return true;
+
+    const haystack = [
+      keycard.keycardNumber,
+      keycard.assignedUser ?? "",
+      getKeycardStatusLabel(keycard.status),
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    return haystack.includes(deferredSearch);
+  });
+
+  const summary = keycards.reduce(
+    (accumulator, keycard) => {
+      accumulator.total += 1;
+
+      if (keycard.status !== "disabled") {
+        accumulator.active += 1;
+      }
+
+      if (keycard.status === "in_use") {
+        accumulator.inUse += 1;
+      }
+
+      if (keycard.status === "available") {
+        accumulator.available += 1;
+      }
+
+      return accumulator;
+    },
+    { total: 0, active: 0, inUse: 0, available: 0 },
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadKeycards = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const page = await getKeycards({ size: 200 });
+        if (!isMounted) return;
+        setKeycards(page.content);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(
+          err instanceof ApiError
+            ? err.message
+            : "Võtmekaartide laadimine ebaõnnestus.",
+        );
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadKeycards();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div className="mx-auto max-w-7xl space-y-8 animate-in fade-in duration-500">
-      {/* 1. BREADCRUMBS & HEADER */}
-      <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+      <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
         <div className="space-y-4">
           <nav className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
-            <Link href="/" className="hover:text-primary transition-colors">
+            <Link href="/" className="transition-colors hover:text-primary">
               Pääsla
             </Link>
             <ChevronRightIcon className="!text-sm" />
             <span className="text-primary">Võtmekaardid</span>
           </nav>
           <div className="space-y-1">
-            <h1 className="text-3xl font-black tracking-tight text-slate-900 dark:text-white font-display">
+            <h1 className="font-display text-3xl font-black tracking-tight text-slate-900">
               Võtmekaartide haldus
             </h1>
-            <p className="text-slate-500 dark:text-slate-400 max-w-2xl font-medium">
-              Monitor ja hallake kõrge turvalisusega RFID pääsukaarte.
-              Sünkroniseeritud keskse läbipääsusüsteemiga.
+            <p className="max-w-2xl text-slate-500">
+              Ava üksik kaart, vaata selle hetke seisu, määramist ja viimaseid
+              teadaolevaid aegu detaillehel.
             </p>
           </div>
         </div>
         <div className="flex gap-3">
           <Button
             variant="outline"
-            className="gap-2 font-bold text-xs uppercase tracking-widest py-6"
+            className="gap-2 py-6 text-xs font-bold uppercase tracking-widest"
           >
-            <FileDownloadIcon className="!text-lg" /> Ekspordi aruanne
+            <FileDownloadIcon className="!text-lg" /> Ekspordi
           </Button>
-          <Button className="gap-2 font-bold text-xs uppercase tracking-widest py-6 px-8 shadow-xl shadow-primary/20 bg-primary">
+          <Button className="gap-2 bg-primary px-8 py-6 text-xs font-bold uppercase tracking-widest shadow-xl shadow-primary/20">
             <AddIcon className="!text-lg" /> Registreeri kaart
           </Button>
         </div>
       </div>
 
-      {/* 2. FILTRITE TOOLBAR */}
-      <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-4 shadow-sm flex flex-wrap items-center gap-4">
-        <div className="flex-1 min-w-[300px] relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400">
+      <div className="flex flex-wrap items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="relative min-w-[280px] flex-1">
+          <div className="absolute top-1/2 left-3 -translate-y-1/2 text-slate-400">
             <FilterListIcon className="!text-lg" />
           </div>
           <input
-            className="w-full pl-10 pr-4 py-2.5 bg-slate-50 dark:bg-slate-800 border-none rounded-xl text-sm font-bold placeholder:text-slate-300"
-            placeholder="Otsi kaardi numbri, kasutaja või osakonna järgi..."
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="w-full rounded-xl bg-slate-50 py-2.5 pr-4 pl-10 text-sm font-semibold text-slate-700 placeholder:text-slate-300"
+            placeholder="Otsi kaardi numbri või kasutaja järgi..."
           />
         </div>
-        <div className="flex items-center gap-2">
-          <FilterButton label="Staatus: Kõik" />
-          <FilterButton label="Tase: Kõik" />
-          <FilterButton label="Asukoht: Tallinn" />
-          <div className="w-px h-6 bg-slate-100 mx-2" />
-          <button
-            className="p-2 text-slate-400 hover:text-primary transition-colors"
-            aria-label="Värskenda filtreid"
-            title="Värskenda filtreid"
-          >
-            <RefreshIcon />
-          </button>
-        </div>
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-xl text-slate-500"
+          aria-label="Värskenda võtmekaarte"
+          onClick={() => window.location.reload()}
+        >
+          <RefreshIcon />
+        </Button>
       </div>
 
-      {/* 3. ANDMETE TABEL */}
-      <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden font-display">
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="overflow-x-auto">
-          <table className="w-full text-left border-collapse">
-            <thead className="bg-slate-50/80 dark:bg-slate-800/50 border-b border-slate-100 text-[10px] font-black uppercase tracking-[0.15em] text-slate-400">
+          <table className="w-full border-collapse text-left">
+            <thead className="border-b border-slate-100 bg-slate-50/80 text-[10px] font-black uppercase tracking-[0.15em] text-slate-400">
               <tr>
                 <th className="px-6 py-5">Kaardi number</th>
-                <th className="px-6 py-5">Turvatase</th>
-                <th className="px-6 py-5 text-center">Staatus</th>
-                <th className="px-6 py-5">Määratud kasutaja</th>
+                <th className="px-6 py-5">Staatus</th>
+                <th className="px-6 py-5">Kasutaja</th>
+                <th className="px-6 py-5">Väljastatud</th>
                 <th className="px-6 py-5">Viimati tagastatud</th>
-                <th className="px-6 py-5"></th>
+                <th className="px-6 py-5 text-right">Tegevus</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-50 dark:divide-slate-800">
-              <KeycardRow
-                id="EE-4920-A1"
-                level="Tase 5 (Piiratud)"
-                status="Saadaval"
-                user="—"
-                date="24. okt, 2023"
-                time="17:45"
-                statusColor="green"
-              />
-              <KeycardRow
-                id="EE-8821-B2"
-                level="Tase 3 (Standard)"
-                status="Kasutuses"
-                user="Mihkel Lepik"
-                date="Praegu väljas"
-                time=""
-                statusColor="blue"
-                initials="ML"
-              />
-              <KeycardRow
-                id="EE-1004-X9"
-                level="Tase 1 (Sissepääs)"
-                status="Deaktiveeritud"
-                user="Arhiveeritud"
-                date="12. sept, 2023"
-                time="09:12"
-                statusColor="red"
-              />
+            <tbody className="divide-y divide-slate-100">
+              {isLoading ? (
+                <LoadingRow />
+              ) : filteredKeycards.length > 0 ? (
+                filteredKeycards.map((keycard) => (
+                  <KeycardRow key={keycard.id} keycard={keycard} />
+                ))
+              ) : (
+                <EmptyRow
+                  title={
+                    error ? "Võtmekaartide laadimine ebaõnnestus" : "Tulemusi ei leitud"
+                  }
+                  description={
+                    error ??
+                    "Muuda otsingut või kontrolli, kas võtmekaardid on süsteemis olemas."
+                  }
+                />
+              )}
             </tbody>
           </table>
         </div>
 
-        {/* PAGINATION */}
-        <div className="px-6 py-4 bg-slate-50/50 border-t border-slate-50 flex items-center justify-between">
-          <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
-            Näitan <span className="text-slate-900">1</span> kuni{" "}
-            <span className="text-slate-900">10</span> /{" "}
-            <span className="text-slate-900">128</span> kaardist
+        <div className="flex items-center justify-between border-t border-slate-100 bg-slate-50/60 px-6 py-4">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+            Näitan <span className="text-slate-900">{filteredKeycards.length}</span>{" "}
+            / <span className="text-slate-900">{keycards.length}</span> kaardist
           </p>
-          <div className="flex items-center gap-1">
-            <PaginationBtn
-              icon={<FirstPageIcon className="!text-sm" />}
-              disabled
-            />
-            <PaginationBtn
-              icon={<ChevronLeftIcon className="!text-sm" />}
-              disabled
-            />
-            <div className="flex items-center gap-1 mx-4">
-              <button className="size-8 bg-primary text-white rounded-lg font-black text-xs">
-                1
-              </button>
-              <button className="size-8 text-slate-400 font-bold text-xs hover:bg-white rounded-lg transition-colors">
-                2
-              </button>
-              <button className="size-8 text-slate-400 font-bold text-xs hover:bg-white rounded-lg transition-colors">
-                3
-              </button>
-            </div>
-            <PaginationBtn icon={<ChevronRightIcon className="!text-sm" />} />
-            <PaginationBtn icon={<LastPageIcon className="!text-sm" />} />
-          </div>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+            Ava detailvaade, et näha määramist ja kaardi olekut
+          </p>
         </div>
       </div>
 
-      {/* 4. ALUMINE STATISTIKA GRUPP */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
         <StatSmall
           title="Kaarte kokku"
-          value="4,250"
-          trend="+12 sel nädalal"
-          icon={<TrendingUpIcon className="!text-sm text-green-500" />}
+          value={summary.total}
+          trend="Kõik süsteemis nähtavad kaardid"
+          icon={<TrendingUpIcon className="!text-sm text-emerald-500" />}
         />
         <StatSmall
-          title="Hetkel aktiivsed"
-          value="842"
-          trend="19% täituvus"
+          title="Aktiivsed"
+          value={summary.active}
+          trend="Saadaval või kasutuses"
           icon={<InfoIcon className="!text-sm text-slate-400" />}
         />
         <StatSmall
-          title="Tagastamata"
-          value="14"
-          trend="Vajab tähelepanu"
-          icon={<WarningIcon className="!text-sm text-orange-500" />}
-          color="text-orange-500"
+          title="Kasutuses"
+          value={summary.inUse}
+          trend="Praegu külastajate käes"
+          icon={<CreditCardIcon className="!text-sm text-blue-600" />}
+          color="text-blue-600"
         />
         <StatSmall
-          title="Kaotatud/Varastatud"
-          value="3"
-          trend="Mustas nimekirjas"
-          icon={<GppMaybeIcon className="!text-sm text-red-500" />}
-          color="text-red-500"
+          title="Saadaval"
+          value={summary.available}
+          trend="Valmis uuesti väljastamiseks"
+          icon={<MeetingRoomIcon className="!text-sm text-emerald-500" />}
+          color="text-emerald-600"
         />
       </div>
     </div>
   );
 }
 
-interface BadgeProps {
-  initials?: string;
-  id: string;
-  level: string;
-  status: string;
-  user: string;
-  date: string;
-  time: string;
-  statusColor: "green" | "blue" | "red";
-}
-
-interface PaginationBtnProps {
-  readonly icon: React.ReactNode;
-  readonly disabled?: boolean; // Valikuline tõeväärtus
-}
-
-interface StatSmallProps {
-  readonly title: string;
-  readonly value: string | number; // väärtus võib olla nii tekst kui number
-  readonly trend: string;
-  readonly icon: React.ReactNode; // See on tüüp ikoonide ja HTML-i jaoks
-  readonly color?: string; // Küsimärk, sest sellel on vaikimisi väärtus
-}
-
-// ABIKOMPONENDID
-
-function FilterButton({ label }: Readonly<{ label: string }>) {
+function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
   return (
-    <button className="px-4 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-100 dark:border-slate-700 rounded-xl text-[10px] font-black uppercase tracking-widest text-slate-500 hover:bg-white hover:shadow-sm transition-all">
-      {label}
-    </button>
-  );
-}
-
-function KeycardRow({
-  id,
-  level,
-  status,
-  user,
-  date,
-  time,
-  statusColor,
-  initials,
-}: Readonly<BadgeProps>) {
-  const badgeStyles: Record<string, string> = {
-    green: "bg-emerald-50 text-emerald-600 border-emerald-100",
-    blue: "bg-blue-50 text-blue-600 border-blue-100",
-    red: "bg-rose-50 text-rose-600 border-rose-100",
-  };
-  return (
-    <tr className="hover:bg-slate-50/50 transition-colors">
+    <tr className="transition-colors hover:bg-slate-50/70">
       <td className="px-6 py-4 whitespace-nowrap">
         <div className="flex items-center gap-3">
-          <div className="size-8 rounded-lg bg-slate-100 flex items-center justify-center text-slate-400">
+          <div className="flex size-8 items-center justify-center rounded-lg bg-slate-100 text-slate-400">
             <CreditCardIcon className="!text-lg" />
           </div>
-          <span className="font-mono text-sm font-bold tracking-tight text-slate-900">
-            {id}
-          </span>
-        </div>
-      </td>
-      <td className="px-6 py-4">
-        <div className="flex items-center gap-2">
-          <SecurityIcon className="!text-sm text-slate-300" />
-          <span className="text-sm font-bold text-slate-700">{level}</span>
-        </div>
-      </td>
-      <td className="px-6 py-4 text-center">
-        <span
-          className={`inline-flex px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border ${badgeStyles[statusColor]}`}
-        >
-          {status}
-        </span>
-      </td>
-      <td className="px-6 py-4">
-        {user === "—" ? (
-          <span className="text-slate-300">—</span>
-        ) : (
-          <div className="flex items-center gap-2">
-            <div className="size-6 rounded-full bg-primary/10 text-primary text-[10px] flex items-center justify-center font-black">
-              {initials}
-            </div>
-            <span className="text-sm font-bold text-slate-900">{user}</span>
+          <div>
+            <Link
+              href={`/keys/${keycard.id}`}
+              className="font-mono text-sm font-bold tracking-tight text-slate-900 transition-colors hover:text-primary"
+            >
+              {keycard.keycardNumber}
+            </Link>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+              ID {keycard.id.slice(0, 8)}
+            </p>
           </div>
+        </div>
+      </td>
+      <td className="px-6 py-4">
+        <StatusBadge status={keycard.status} />
+      </td>
+      <td className="px-6 py-4">
+        {keycard.assignedUser ? (
+          <p className="text-sm font-semibold text-slate-900">
+            {keycard.assignedUser}
+          </p>
+        ) : (
+          <p className="text-sm text-slate-400">Määramata</p>
         )}
       </td>
       <td className="px-6 py-4">
-        <div className="text-sm font-bold text-slate-900">{date}</div>
-        <div className="text-[10px] font-bold text-slate-400 uppercase tracking-tighter">
-          {time}
-        </div>
+        <DateTimeStack value={keycard.assignedTime} emptyLabel="Pole väljastatud" />
+      </td>
+      <td className="px-6 py-4">
+        <DateTimeStack
+          value={keycard.lastReturnTime}
+          emptyLabel="Tagastus puudub"
+        />
       </td>
       <td className="px-6 py-4 text-right">
-        <button className="text-slate-300 hover:text-primary transition-colors">
-          <MoreVertIcon />
-        </button>
+        <Button asChild variant="ghost" className="rounded-xl text-primary">
+          <Link href={`/keys/${keycard.id}`}>
+            Ava <VisibilityIcon className="!text-base" />
+          </Link>
+        </Button>
+      </td>
+    </tr>
+  );
+}
+
+function StatusBadge({
+  status,
+}: Readonly<{ status: KeycardResponse["status"] }>) {
+  const styles: Record<KeycardResponse["status"], string> = {
+    available: "border-emerald-100 bg-emerald-50 text-emerald-700",
+    in_use: "border-blue-100 bg-blue-50 text-blue-700",
+    disabled: "border-rose-100 bg-rose-50 text-rose-700",
+  };
+
+  return (
+    <span
+      className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-widest ${styles[status]}`}
+    >
+      {getKeycardStatusLabel(status)}
+    </span>
+  );
+}
+
+function DateTimeStack({
+  value,
+  emptyLabel,
+}: Readonly<{
+  value: string | null;
+  emptyLabel: string;
+}>) {
+  if (!value) {
+    return <p className="text-sm text-slate-400">{emptyLabel}</p>;
+  }
+
+  const date = new Date(value);
+
+  return (
+    <div>
+      <div className="text-sm font-semibold text-slate-900">
+        {new Intl.DateTimeFormat("et-EE", { dateStyle: "medium" }).format(date)}
+      </div>
+      <div className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+        {new Intl.DateTimeFormat("et-EE", { timeStyle: "short" }).format(date)}
+      </div>
+    </div>
+  );
+}
+
+function LoadingRow() {
+  return (
+    <tr>
+      <td colSpan={6} className="px-6 py-14 text-center">
+        <p className="text-sm font-semibold text-slate-600">
+          Laen võtmekaarte...
+        </p>
+      </td>
+    </tr>
+  );
+}
+
+function EmptyRow({
+  title,
+  description,
+}: Readonly<{
+  title: string;
+  description: string;
+}>) {
+  return (
+    <tr>
+      <td colSpan={6} className="px-6 py-14 text-center">
+        <p className="text-sm font-semibold text-slate-900">{title}</p>
+        <p className="mt-2 text-sm text-slate-500">{description}</p>
       </td>
     </tr>
   );
@@ -298,27 +361,22 @@ function StatSmall({
   trend,
   icon,
   color = "text-slate-900",
-}: StatSmallProps) {
+}: Readonly<{
+  title: string;
+  value: string | number;
+  trend: string;
+  icon: ReactNode;
+  color?: string;
+}>) {
   return (
-    <div className="bg-white p-5 rounded-2xl border border-slate-100 shadow-sm">
-      <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest mb-1">
+    <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
+      <p className="mb-1 text-[10px] font-black uppercase tracking-widest text-slate-400">
         {title}
       </p>
       <p className={`text-2xl font-black tracking-tighter ${color}`}>{value}</p>
-      <div className="mt-2 flex items-center gap-1 text-[10px] font-bold uppercase tracking-tighter">
+      <div className="mt-2 flex items-center gap-1 text-[10px] font-bold uppercase tracking-tighter text-slate-500">
         {icon} {trend}
       </div>
     </div>
-  );
-}
-
-function PaginationBtn({ icon, disabled }: PaginationBtnProps) {
-  return (
-    <button
-      disabled={disabled}
-      className="p-2 text-slate-300 hover:bg-white hover:text-primary rounded-lg transition-all disabled:opacity-20"
-    >
-      {icon}
-    </button>
   );
 }

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -275,10 +275,7 @@ function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
       </td>
       <td className="relative px-6 py-4">
         <Link href={href} className="absolute inset-0 z-10" tabIndex={-1} />
-        <DateTimeStack
-          value={keycard.assignedTime}
-          emptyLabel="Pole väljastatud"
-        />
+        <DateTimeStack value={keycard.assignedTime} emptyLabel="Puudub" />
       </td>
       <td className="relative px-6 py-4">
         <Link href={href} className="absolute inset-0 z-10" tabIndex={-1} />
@@ -298,6 +295,7 @@ function StatusBadge({
     available: "border-emerald-100 bg-emerald-50 text-emerald-700",
     in_use: "border-blue-100 bg-blue-50 text-blue-700",
     disabled: "border-rose-100 bg-rose-50 text-rose-700",
+    expired: "border-amber-100 bg-amber-50 text-amber-700",
   };
 
   return (

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -301,7 +301,7 @@ export default function KeycardsPage() {
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-left">
-            <thead className="border-b border-slate-100 bg-slate-50/80 text-[10px] font-black uppercase tracking-[0.15em] text-slate-400">
+            <thead className="border-b border-slate-100 bg-slate-50/80 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
               <tr>
                 <th className="px-6 py-5">
                   <SortableHeader
@@ -607,7 +607,7 @@ function SortableHeader({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-full w-full items-center justify-between gap-2 text-left select-none transition-colors hover:text-slate-600"
+      className="flex h-full w-full items-center justify-between gap-2 text-left font-black uppercase select-none transition-colors hover:text-slate-600"
     >
       <span>{label}</span>
       {direction === "asc" ? (

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { type ReactNode, useDeferredValue, useEffect, useState } from "react";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
 import FilterListIcon from "@mui/icons-material/FilterList";
@@ -11,7 +12,6 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
 import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import InfoIcon from "@mui/icons-material/Info";
-import VisibilityIcon from "@mui/icons-material/Visibility";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/apiClient";
 import {
@@ -184,7 +184,6 @@ export default function KeycardsPage() {
                 <th className="px-6 py-5">Kasutaja</th>
                 <th className="px-6 py-5">Väljastatud</th>
                 <th className="px-6 py-5">Viimati tagastatud</th>
-                <th className="px-6 py-5 text-right">Tegevus</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
@@ -238,20 +237,34 @@ export default function KeycardsPage() {
 }
 
 function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
+  const router = useRouter();
+  const href = `/keys/${keycard.id}`;
+
   return (
-    <tr className="transition-colors hover:bg-slate-50/70">
+    <tr
+      tabIndex={0}
+      role="link"
+      aria-label={`Ava võtmekaart ${keycard.keycardNumber}`}
+      className="cursor-pointer transition-colors hover:bg-slate-50/70 focus-visible:bg-slate-50/70 focus-visible:outline-2 focus-visible:outline-primary/40"
+      onClick={() => router.push(href)}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") {
+          return;
+        }
+
+        event.preventDefault();
+        router.push(href);
+      }}
+    >
       <td className="px-6 py-4 whitespace-nowrap">
         <div className="flex items-center gap-3">
           <div className="flex size-8 items-center justify-center rounded-lg bg-slate-100 text-slate-400">
             <CreditCardIcon className="!text-lg" />
           </div>
           <div>
-            <Link
-              href={`/keys/${keycard.id}`}
-              className="font-mono text-sm font-bold tracking-tight text-slate-900 transition-colors hover:text-primary"
-            >
+            <p className="font-mono text-sm font-bold tracking-tight text-slate-900">
               {keycard.keycardNumber}
-            </Link>
+            </p>
             <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
               ID {keycard.id.slice(0, 8)}
             </p>
@@ -281,13 +294,6 @@ function KeycardRow({ keycard }: Readonly<{ keycard: KeycardResponse }>) {
           value={keycard.lastReturnTime}
           emptyLabel="Tagastus puudub"
         />
-      </td>
-      <td className="px-6 py-4 text-right">
-        <Button asChild variant="ghost" className="rounded-xl text-primary">
-          <Link href={`/keys/${keycard.id}`}>
-            Ava <VisibilityIcon className="!text-base" />
-          </Link>
-        </Button>
       </td>
     </tr>
   );
@@ -339,7 +345,7 @@ function DateTimeStack({
 function LoadingRow() {
   return (
     <tr>
-      <td colSpan={6} className="px-6 py-14 text-center">
+      <td colSpan={5} className="px-6 py-14 text-center">
         <p className="text-sm font-semibold text-slate-600">
           Laen võtmekaarte...
         </p>
@@ -357,7 +363,7 @@ function EmptyRow({
 }>) {
   return (
     <tr>
-      <td colSpan={6} className="px-6 py-14 text-center">
+      <td colSpan={5} className="px-6 py-14 text-center">
         <p className="text-sm font-semibold text-slate-900">{title}</p>
         <p className="mt-2 text-sm text-slate-500">{description}</p>
       </td>

--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -518,7 +518,7 @@ export default function NewVisitPage() {
         {/* ── Section 3: Keycard ── */}
         <Card
           icon={<CreditCardIcon className="text-blue-700 !text-xl" />}
-          title="Kiipkaardi määramine"
+          title="Võtmekaardi määramine"
         >
           <div className="flex items-center gap-3">
             <select
@@ -543,7 +543,7 @@ export default function NewVisitPage() {
           <div className="flex gap-2 px-3 py-3 bg-blue-50 rounded-lg text-xs text-slate-600">
             <InfoOutlinedIcon className="!text-base text-blue-500 shrink-0 mt-0.5" />
             <span>
-              Kiipkaardi väljastamisel aktiveerub see koheselt valitud
+              Võtmekaardi väljastamisel aktiveerub see koheselt valitud
               pääsupunktides. Külaline on kohustatud kaardi tagastama külastuse
               lõpus. Kadunud kaardist teavitada viivitamatult administraatorit.
             </span>

--- a/lib/api/keycards.ts
+++ b/lib/api/keycards.ts
@@ -24,6 +24,10 @@ export interface KeycardDetailResponse extends KeycardResponse {
   assignedPersonInRoleId: string | null;
 }
 
+export interface ReturnKeycardRequest {
+  returnAccessPointId: string;
+}
+
 export interface KeycardListPage {
   content: KeycardResponse[];
   page: PageMetadata | null;
@@ -95,6 +99,16 @@ export async function getKeycard(
     ...summary,
     assignedPersonInRoleId: pickString(record, ["assignedPersonInRoleId"]),
   };
+}
+
+export function returnKeycard(
+  cardId: string,
+  body: ReturnKeycardRequest,
+): Promise<KeycardDetailResponse> {
+  return apiClient.post<KeycardDetailResponse, ReturnKeycardRequest>(
+    `/api/keycards/${cardId}/return`,
+    body,
+  );
 }
 
 export function getKeycardStatusLabel(status: KeycardStatus): string {

--- a/lib/api/keycards.ts
+++ b/lib/api/keycards.ts
@@ -1,20 +1,202 @@
 import { apiClient } from "@/lib/apiClient";
 
+export type KeycardStatus = "available" | "in_use" | "disabled";
+
+export interface PageMetadata {
+  size: number;
+  number: number;
+  totalElements: number;
+  totalPages: number;
+}
+
 export interface KeycardResponse {
   id: string;
   keycardNumber: string;
-  status: string;
+  active: boolean;
+  status: KeycardStatus;
   assignedUser: string | null;
+  assignedTime: string | null;
   lastReturnTime: string | null;
+  validUntil: string | null;
 }
 
-interface KeycardPage {
+export interface KeycardDetailResponse extends KeycardResponse {
+  assignedPersonInRoleId: string | null;
+}
+
+export interface KeycardListPage {
   content: KeycardResponse[];
+  page: PageMetadata | null;
+}
+
+interface KeycardQueryOptions {
+  page?: number;
+  size?: number;
+  search?: string;
+  status?: KeycardStatus;
+}
+
+interface RawPagedResponse {
+  content?: unknown[];
+  page?: Partial<PageMetadata>;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+export async function getKeycards(
+  options: KeycardQueryOptions = {},
+): Promise<KeycardListPage> {
+  const params = new URLSearchParams();
+  params.set("page", String(options.page ?? 0));
+  params.set("size", String(options.size ?? 100));
+
+  if (options.search) {
+    params.set("search", options.search);
+  }
+
+  if (options.status) {
+    params.set("status", options.status);
+  }
+
+  const page = await apiClient.get<RawPagedResponse>(
+    `/api/keycards?${params.toString()}`,
+  );
+
+  return {
+    content: Array.isArray(page.content)
+      ? page.content.map(mapKeycardSummary).filter(isDefined)
+      : [],
+    page: page.page ? mapPageMetadata(page.page) : null,
+  };
 }
 
 export async function getAvailableKeycards(): Promise<KeycardResponse[]> {
-  const page = await apiClient.get<KeycardPage>(
-    "/api/keycards?status=available&size=200",
-  );
+  const page = await getKeycards({ status: "available", size: 200 });
   return page.content;
+}
+
+export async function getKeycard(
+  cardId: string,
+): Promise<KeycardDetailResponse> {
+  const raw = await apiClient.get<unknown>(`/api/keycards/${cardId}`);
+  const record = asRecord(raw);
+
+  if (!record) {
+    throw new Error("Võtmekaardi andmeid ei õnnestunud töödelda.");
+  }
+
+  const summary = mapKeycardSummary(record);
+
+  if (!summary) {
+    throw new Error("Võtmekaardi andmeid ei õnnestunud töödelda.");
+  }
+
+  return {
+    ...summary,
+    assignedPersonInRoleId: pickString(record, ["assignedPersonInRoleId"]),
+  };
+}
+
+export function getKeycardStatusLabel(status: KeycardStatus): string {
+  switch (status) {
+    case "available":
+      return "Saadaval";
+    case "in_use":
+      return "Kasutuses";
+    case "disabled":
+      return "Deaktiveeritud";
+  }
+}
+
+function mapPageMetadata(page: Partial<PageMetadata>): PageMetadata {
+  return {
+    size: Number(page.size ?? 0),
+    number: Number(page.number ?? 0),
+    totalElements: Number(page.totalElements ?? 0),
+    totalPages: Number(page.totalPages ?? 0),
+  };
+}
+
+function mapKeycardSummary(raw: unknown): KeycardResponse | null {
+  const record = asRecord(raw);
+
+  if (!record) {
+    return null;
+  }
+
+  const id = pickString(record, ["id"]);
+  const keycardNumber = pickString(record, ["keycardNumber"]);
+
+  if (!id || !keycardNumber) {
+    return null;
+  }
+
+  const active = pickBoolean(record, ["active"]) ?? true;
+  const assignedUser = pickString(record, ["assignedUser"]);
+  const assignedTime = pickString(record, ["assignedTime"]);
+  const lastReturnTime = pickString(record, ["lastReturnTime"]);
+  const validUntil = pickString(record, ["validUntil"]);
+
+  return {
+    id,
+    keycardNumber,
+    active,
+    status: normalizeStatus(active, assignedUser, assignedTime),
+    assignedUser,
+    assignedTime,
+    lastReturnTime,
+    validUntil,
+  };
+}
+
+function normalizeStatus(
+  active: boolean,
+  assignedUser: string | null,
+  assignedTime: string | null,
+): KeycardStatus {
+  if (!active) {
+    return "disabled";
+  }
+
+  if (assignedUser || assignedTime) {
+    return "in_use";
+  }
+
+  return "available";
+}
+
+function pickString(record: UnknownRecord, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function pickBoolean(record: UnknownRecord, keys: string[]): boolean | null {
+  for (const key of keys) {
+    const value = record[key];
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function asRecord(value: unknown): UnknownRecord | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as UnknownRecord;
+}
+
+function isDefined<TValue>(value: TValue | null): value is TValue {
+  return value !== null;
 }

--- a/lib/api/keycards.ts
+++ b/lib/api/keycards.ts
@@ -1,6 +1,6 @@
 import { apiClient } from "@/lib/apiClient";
 
-export type KeycardStatus = "available" | "in_use" | "disabled";
+export type KeycardStatus = "available" | "in_use" | "disabled" | "expired";
 
 export interface PageMetadata {
   size: number;
@@ -119,6 +119,8 @@ export function getKeycardStatusLabel(status: KeycardStatus): string {
       return "Kasutuses";
     case "disabled":
       return "Deaktiveeritud";
+    case "expired":
+      return "Aegunud";
   }
 }
 
@@ -145,17 +147,22 @@ function mapKeycardSummary(raw: unknown): KeycardResponse | null {
     return null;
   }
 
-  const active = pickBoolean(record, ["active"]) ?? true;
+  const rawActive = pickBoolean(record, ["active"]);
   const assignedUser = pickString(record, ["assignedUser"]);
   const assignedTime = pickString(record, ["assignedTime"]);
   const lastReturnTime = pickString(record, ["lastReturnTime"]);
   const validUntil = pickString(record, ["validUntil"]);
+  const rawStatus = pickString(record, ["status"]);
+  const status =
+    mapRawStatus(rawStatus) ??
+    normalizeStatus(rawActive ?? true, assignedUser, assignedTime);
+  const active = rawActive ?? status !== "disabled";
 
   return {
     id,
     keycardNumber,
     active,
-    status: normalizeStatus(active, assignedUser, assignedTime),
+    status,
     assignedUser,
     assignedTime,
     lastReturnTime,
@@ -177,6 +184,21 @@ function normalizeStatus(
   }
 
   return "available";
+}
+
+function mapRawStatus(status: string | null): KeycardStatus | null {
+  switch (status?.toUpperCase()) {
+    case "AVAILABLE":
+      return "available";
+    case "IN_USE":
+      return "in_use";
+    case "DISABLED":
+      return "disabled";
+    case "EXPIRED":
+      return "expired";
+    default:
+      return null;
+  }
 }
 
 function pickString(record: UnknownRecord, keys: string[]): string | null {


### PR DESCRIPTION
# Description

## Summary

Adds a dedicated keycard details page at `/keys/[id]` and links it from the existing `/keys` list view.
```bash
http://localhost:3000/keys/a7000000-0000-0000-0000-000000000001
```
<img width="1174" height="808" alt="image" src="https://github.com/user-attachments/assets/fc9357d8-cc09-4db9-95f3-319d5571c8f1" />

The new page shows:
- keycard number
- current assignment state
- active holder
- holder `person_in_role` link state
- assignment time
- last return time
- card validity and active status

The `/keys` page was also updated so users can open a single card directly from the list.

### Why

The existing `/keys` view only showed high-level card data and did not provide a dedicated place to inspect one specific keycard.

This change gives staff a clearer per-card view and aligns the frontend with the currently available backend `GET /api/keycards/{cardId}` response. It also makes the current backend limitation explicit: full issue/return history, assigner, and desk-level handover details are not yet available from this endpoint.

### Related Issue

Closes #<issue-number>

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Styling / UI update
- [ ] Other

## Checklist

- [x] I reviewed my own changes
- [ ] I added or updated documentation where needed
- [x] I ran `npm run lint`
- [x] I ran `npx prettier --check .`
- [x] My changes were tested locally
- [x] I linked the related issue
- [x] This PR is ready for review

## Screenshots

N/A

## Additional Notes

The frontend now follows the current backend contract for `GET /api/keycards/{cardId}` exactly.

This PR does **not** implement full assignment/usage history because the current detail endpoint does not return:
- assigner
- issuing desk
- return desk
- ordered history entries

If backend support for history is added later, the details page can be extended to render it.
