### PR TITLE
feature/49 user management

### DIFF
--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -26,10 +26,14 @@ const inputCls =
 const SKELETON_KEYS = ["sk-a", "sk-b", "sk-c", "sk-d"];
 
 function validatePassword(password: string, confirm: string): string | null {
-  if (password.length < 8) return "Parool peab olema vähemalt 8 tähemärki pikk.";
-  if (!/[A-Z]/.test(password)) return "Parool peab sisaldama vähemalt ühte suurtähte.";
-  if (!/[a-z]/.test(password)) return "Parool peab sisaldama vähemalt ühte väiketähte.";
-  if (!/[^A-Za-z0-9]/.test(password)) return "Parool peab sisaldama vähemalt ühte erimärki.";
+  if (password.length < 8)
+    return "Parool peab olema vähemalt 8 tähemärki pikk.";
+  if (!/[A-Z]/.test(password))
+    return "Parool peab sisaldama vähemalt ühte suurtähte.";
+  if (!/[a-z]/.test(password))
+    return "Parool peab sisaldama vähemalt ühte väiketähte.";
+  if (!/[^A-Za-z0-9]/.test(password))
+    return "Parool peab sisaldama vähemalt ühte erimärki.";
   if (password !== confirm) return "Paroolid ei kattu.";
   return null;
 }
@@ -118,7 +122,9 @@ export default function ProfilePage() {
   }
 
   const { person } = me;
-  const displayName = person ? `${person.givenName} ${person.surname}` : me.email;
+  const displayName = person
+    ? `${person.givenName} ${person.surname}`
+    : me.email;
   const initials = person
     ? `${person.givenName[0]}${person.surname[0]}`.toUpperCase()
     : me.email[0].toUpperCase();
@@ -146,12 +152,36 @@ export default function ProfilePage() {
         <Row icon={<ShieldIcon />} label="Roll" value={ROLE_LABELS[me.role]} />
         {person ? (
           <>
-            <Row icon={<BadgeIcon />} label="Eesnimi" value={person.givenName} />
-            <Row icon={<BadgeIcon />} label="Perekonnanimi" value={person.surname} />
-            <Row icon={<FingerprintIcon />} label="Isikukood" value={person.socialSecurityNumber} />
-            <Row icon={<WorkIcon />} label="Ametinimetus" value={person.jobTitle} />
-            <Row icon={<AccountTreeIcon />} label="Osakond" value={person.department} />
-            <Row icon={<BusinessIcon />} label="Organisatsioon" value={person.organization} />
+            <Row
+              icon={<BadgeIcon />}
+              label="Eesnimi"
+              value={person.givenName}
+            />
+            <Row
+              icon={<BadgeIcon />}
+              label="Perekonnanimi"
+              value={person.surname}
+            />
+            <Row
+              icon={<FingerprintIcon />}
+              label="Isikukood"
+              value={person.socialSecurityNumber}
+            />
+            <Row
+              icon={<WorkIcon />}
+              label="Ametinimetus"
+              value={person.jobTitle}
+            />
+            <Row
+              icon={<AccountTreeIcon />}
+              label="Osakond"
+              value={person.department}
+            />
+            <Row
+              icon={<BusinessIcon />}
+              label="Organisatsioon"
+              value={person.organization}
+            />
           </>
         ) : (
           <div className="px-6 py-4 text-sm text-slate-400">
@@ -169,7 +199,10 @@ export default function ProfilePage() {
 
         <form onSubmit={handleSave} className="space-y-4">
           <div className="space-y-1.5">
-            <label htmlFor="new-email" className="block text-sm font-medium text-slate-700">
+            <label
+              htmlFor="new-email"
+              className="block text-sm font-medium text-slate-700"
+            >
               Uus e-post
             </label>
             <input
@@ -190,7 +223,10 @@ export default function ProfilePage() {
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="new-password" className="block text-sm font-medium text-slate-700">
+            <label
+              htmlFor="new-password"
+              className="block text-sm font-medium text-slate-700"
+            >
               Uus parool
             </label>
             <input
@@ -205,7 +241,10 @@ export default function ProfilePage() {
 
           {newPassword && (
             <div className="space-y-1.5">
-              <label htmlFor="confirm-password" className="block text-sm font-medium text-slate-700">
+              <label
+                htmlFor="confirm-password"
+                className="block text-sm font-medium text-slate-700"
+              >
                 Korda parooli
               </label>
               <input
@@ -258,7 +297,9 @@ function Row({
 }) {
   return (
     <div className="flex items-center gap-4 px-6 py-4">
-      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">{icon}</span>
+      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">
+        {icon}
+      </span>
       <div className="min-w-0">
         <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
           {label}

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -94,7 +94,9 @@ export default function ProfilePage() {
       setSaveSuccess(true);
     } catch (err) {
       setSaveError(
-        err instanceof ApiError ? err.message : "Salvestamine ebaõnnestus. Proovi uuesti.",
+        err instanceof ApiError
+          ? err.message
+          : "Salvestamine ebaõnnestus. Proovi uuesti.",
       );
     } finally {
       setIsSaving(false);
@@ -120,7 +122,9 @@ export default function ProfilePage() {
   }
 
   const { person } = me;
-  const displayName = person ? `${person.givenName} ${person.surname}` : me.email;
+  const displayName = person
+    ? `${person.givenName} ${person.surname}`
+    : me.email;
   const initials = person
     ? `${person.givenName[0]}${person.surname[0]}`.toUpperCase()
     : me.email[0].toUpperCase();
@@ -148,12 +152,36 @@ export default function ProfilePage() {
         <Row icon={<ShieldIcon />} label="Roll" value={ROLE_LABELS[me.role]} />
         {person ? (
           <>
-            <Row icon={<BadgeIcon />} label="Eesnimi" value={person.givenName} />
-            <Row icon={<BadgeIcon />} label="Perekonnanimi" value={person.surname} />
-            <Row icon={<FingerprintIcon />} label="Isikukood" value={person.socialSecurityNumber} />
-            <Row icon={<WorkIcon />} label="Ametinimetus" value={person.jobTitle} />
-            <Row icon={<AccountTreeIcon />} label="Osakond" value={person.department} />
-            <Row icon={<BusinessIcon />} label="Organisatsioon" value={person.organization} />
+            <Row
+              icon={<BadgeIcon />}
+              label="Eesnimi"
+              value={person.givenName}
+            />
+            <Row
+              icon={<BadgeIcon />}
+              label="Perekonnanimi"
+              value={person.surname}
+            />
+            <Row
+              icon={<FingerprintIcon />}
+              label="Isikukood"
+              value={person.socialSecurityNumber}
+            />
+            <Row
+              icon={<WorkIcon />}
+              label="Ametinimetus"
+              value={person.jobTitle}
+            />
+            <Row
+              icon={<AccountTreeIcon />}
+              label="Osakond"
+              value={person.department}
+            />
+            <Row
+              icon={<BusinessIcon />}
+              label="Organisatsioon"
+              value={person.organization}
+            />
           </>
         ) : (
           <div className="px-6 py-4 text-sm text-slate-400">
@@ -184,7 +212,8 @@ export default function ProfilePage() {
             />
             {newEmail && (
               <p className="text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
-                Ettevaatust! E-posti vahetamisel logitakse teid automaatselt välja ja te peate uue e-posti aadressiga uuesti sisse logima.
+                Ettevaatust! E-posti vahetamisel logitakse teid automaatselt
+                välja ja te peate uue e-posti aadressiga uuesti sisse logima.
               </p>
             )}
           </div>
@@ -256,7 +285,9 @@ function Row({
 }) {
   return (
     <div className="flex items-center gap-4 px-6 py-4">
-      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">{icon}</span>
+      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">
+        {icon}
+      </span>
       <div className="min-w-0">
         <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
           {label}

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import BadgeIcon from "@mui/icons-material/Badge";
+import EmailIcon from "@mui/icons-material/Email";
+import BusinessIcon from "@mui/icons-material/Business";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import WorkIcon from "@mui/icons-material/Work";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
+import ShieldIcon from "@mui/icons-material/Shield";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { getMe, updateMe, type MeResponse } from "@/lib/api/auth";
+import { ApiError } from "@/lib/apiClient";
+
+const ROLE_LABELS: Record<MeResponse["role"], string> = {
+  VISITOR: "Külastaja",
+  RECEPTIONIST: "Administraator",
+  SECURITY_CHIEF: "Turvaülem",
+  ADMIN: "Süsteemiadmin",
+};
+
+const inputCls =
+  "w-full px-3 py-2.5 rounded-lg border border-slate-200 bg-white text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-600/20 focus:border-blue-600 transition";
+
+export default function ProfilePage() {
+  const [me, setMe] = useState<MeResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Edit form state
+  const [newEmail, setNewEmail] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  useEffect(() => {
+    getMe()
+      .then(setMe)
+      .catch((err) => {
+        if (err instanceof ApiError) setLoadError(err.message);
+      });
+  }, []);
+
+  const handleSave = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    if (!newEmail && !newPassword) {
+      setSaveError("Sisesta uus e-post ja/või uus parool.");
+      return;
+    }
+    if (newPassword) {
+      if (newPassword.length < 8) {
+        setSaveError("Parool peab olema vähemalt 8 tähemärki pikk.");
+        return;
+      }
+      if (!/[A-Z]/.test(newPassword)) {
+        setSaveError("Parool peab sisaldama vähemalt ühte suurtähte.");
+        return;
+      }
+      if (!/[a-z]/.test(newPassword)) {
+        setSaveError("Parool peab sisaldama vähemalt ühte väiketähte.");
+        return;
+      }
+      if (!/[^A-Za-z0-9]/.test(newPassword)) {
+        setSaveError("Parool peab sisaldama vähemalt ühte erimärki.");
+        return;
+      }
+      if (newPassword !== confirmPassword) {
+        setSaveError("Paroolid ei kattu.");
+        return;
+      }
+    }
+
+    const body: { email?: string; password?: string } = {};
+    if (newEmail) body.email = newEmail;
+    if (newPassword) body.password = newPassword;
+
+    setIsSaving(true);
+    try {
+      await updateMe(body);
+      if (newEmail) {
+        // JWT subject is the old email — token is now stale, must re-login.
+        localStorage.removeItem("token");
+        document.cookie = "token=; path=/; max-age=0";
+        window.location.href = "/login";
+        return;
+      }
+      setNewPassword("");
+      setConfirmPassword("");
+      setSaveSuccess(true);
+    } catch (err) {
+      setSaveError(
+        err instanceof ApiError ? err.message : "Salvestamine ebaõnnestus. Proovi uuesti.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <p className="text-sm font-semibold text-rose-600 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+        {loadError}
+      </p>
+    );
+  }
+
+  if (!me) {
+    return (
+      <div className="max-w-xl mx-auto space-y-4 animate-pulse">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-16 rounded-2xl bg-slate-100" />
+        ))}
+      </div>
+    );
+  }
+
+  const { person } = me;
+  const displayName = person ? `${person.givenName} ${person.surname}` : me.email;
+  const initials = person
+    ? `${person.givenName[0]}${person.surname[0]}`.toUpperCase()
+    : me.email[0].toUpperCase();
+
+  return (
+    <div className="max-w-xl mx-auto space-y-6 animate-in fade-in duration-500 pb-12">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <div className="size-16 rounded-2xl bg-blue-700 text-white flex items-center justify-center font-black text-xl">
+          {initials}
+        </div>
+        <div>
+          <h2 className="text-2xl font-black text-slate-900 tracking-tight">
+            {displayName}
+          </h2>
+          <p className="text-sm text-slate-500">
+            {person?.jobTitle ?? ROLE_LABELS[me.role]}
+          </p>
+        </div>
+      </div>
+
+      {/* Profile info */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm divide-y divide-slate-100">
+        <Row icon={<EmailIcon />} label="E-post" value={me.email} />
+        <Row icon={<ShieldIcon />} label="Roll" value={ROLE_LABELS[me.role]} />
+        {person ? (
+          <>
+            <Row icon={<BadgeIcon />} label="Eesnimi" value={person.givenName} />
+            <Row icon={<BadgeIcon />} label="Perekonnanimi" value={person.surname} />
+            <Row icon={<FingerprintIcon />} label="Isikukood" value={person.socialSecurityNumber} />
+            <Row icon={<WorkIcon />} label="Ametinimetus" value={person.jobTitle} />
+            <Row icon={<AccountTreeIcon />} label="Osakond" value={person.department} />
+            <Row icon={<BusinessIcon />} label="Organisatsioon" value={person.organization} />
+          </>
+        ) : (
+          <div className="px-6 py-4 text-sm text-slate-400">
+            Isikuandmed puuduvad — kasutajaga ei ole seotud isikukirjet.
+          </div>
+        )}
+      </div>
+
+      {/* Change email / password */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-6 space-y-4">
+        <h3 className="flex items-center gap-2 text-base font-bold text-slate-800">
+          <LockOutlinedIcon className="text-blue-700 !text-xl" />
+          Muuda e-posti või parooli
+        </h3>
+
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-slate-700">
+              Uus e-post
+            </label>
+            <input
+              type="email"
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              placeholder={me.email}
+              maxLength={255}
+              className={inputCls}
+            />
+            {newEmail && (
+              <p className="text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+                Ettevaatust! E-posti vahetamisel logitakse teid automaatselt välja ja te peate uue e-posti aadressiga uuesti sisse logima.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-slate-700">
+              Uus parool
+            </label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="Sisesta uus parool"
+              className={inputCls}
+            />
+          </div>
+
+          {newPassword && (
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-slate-700">
+                Korda parooli
+              </label>
+              <input
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="Korda uut parooli"
+                className={inputCls}
+              />
+            </div>
+          )}
+
+          {saveError && (
+            <p className="text-sm font-semibold text-rose-600 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+              {saveError}
+            </p>
+          )}
+
+          {saveSuccess && (
+            <p className="flex items-center gap-2 text-sm font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-xl px-4 py-3">
+              <CheckCircleIcon className="!text-base" />
+              Andmed uuendatud.
+            </p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="px-6 py-2.5 bg-blue-700 hover:bg-blue-800 disabled:opacity-50 text-white text-sm font-bold rounded-xl transition-colors"
+            >
+              {isSaving ? "Salvestan…" : "Salvesta muudatused"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  icon,
+  label,
+  value,
+}: {
+  readonly icon: React.ReactNode;
+  readonly label: string;
+  readonly value: string | null | undefined;
+}) {
+  return (
+    <div className="flex items-center gap-4 px-6 py-4">
+      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">{icon}</span>
+      <div className="min-w-0">
+        <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+          {label}
+        </p>
+        <p className="text-sm font-semibold text-slate-800 truncate">
+          {value ?? <span className="text-slate-400 font-normal">—</span>}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -229,7 +229,8 @@ export default function ProfilePage() {
             >
               Uus parool{" "}
               <span className="text-xs font-normal text-slate-400">
-                (vähemalt 1 väike täht, 1 suur täht, 1 erisümbol, vähemalt 8 sümbolit)
+                (vähemalt 1 väike täht, 1 suur täht, 1 erisümbol, vähemalt 8
+                sümbolit)
               </span>
             </label>
             <input

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -23,11 +23,21 @@ const ROLE_LABELS: Record<MeResponse["role"], string> = {
 const inputCls =
   "w-full px-3 py-2.5 rounded-lg border border-slate-200 bg-white text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-600/20 focus:border-blue-600 transition";
 
+const SKELETON_KEYS = ["sk-a", "sk-b", "sk-c", "sk-d"];
+
+function validatePassword(password: string, confirm: string): string | null {
+  if (password.length < 8) return "Parool peab olema vähemalt 8 tähemärki pikk.";
+  if (!/[A-Z]/.test(password)) return "Parool peab sisaldama vähemalt ühte suurtähte.";
+  if (!/[a-z]/.test(password)) return "Parool peab sisaldama vähemalt ühte väiketähte.";
+  if (!/[^A-Za-z0-9]/.test(password)) return "Parool peab sisaldama vähemalt ühte erimärki.";
+  if (password !== confirm) return "Paroolid ei kattu.";
+  return null;
+}
+
 export default function ProfilePage() {
   const [me, setMe] = useState<MeResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  // Edit form state
   const [newEmail, setNewEmail] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -52,25 +62,11 @@ export default function ProfilePage() {
       setSaveError("Sisesta uus e-post ja/või uus parool.");
       return;
     }
+
     if (newPassword) {
-      if (newPassword.length < 8) {
-        setSaveError("Parool peab olema vähemalt 8 tähemärki pikk.");
-        return;
-      }
-      if (!/[A-Z]/.test(newPassword)) {
-        setSaveError("Parool peab sisaldama vähemalt ühte suurtähte.");
-        return;
-      }
-      if (!/[a-z]/.test(newPassword)) {
-        setSaveError("Parool peab sisaldama vähemalt ühte väiketähte.");
-        return;
-      }
-      if (!/[^A-Za-z0-9]/.test(newPassword)) {
-        setSaveError("Parool peab sisaldama vähemalt ühte erimärki.");
-        return;
-      }
-      if (newPassword !== confirmPassword) {
-        setSaveError("Paroolid ei kattu.");
+      const passwordError = validatePassword(newPassword, confirmPassword);
+      if (passwordError) {
+        setSaveError(passwordError);
         return;
       }
     }
@@ -84,9 +80,9 @@ export default function ProfilePage() {
       await updateMe(body);
       if (newEmail) {
         // JWT subject is the old email — token is now stale, must re-login.
-        localStorage.removeItem("token");
-        document.cookie = "token=; path=/; max-age=0";
-        window.location.href = "/login";
+        globalThis.localStorage.removeItem("token");
+        globalThis.document.cookie = "token=; path=/; max-age=0";
+        globalThis.window.location.href = "/login";
         return;
       }
       setNewPassword("");
@@ -114,17 +110,15 @@ export default function ProfilePage() {
   if (!me) {
     return (
       <div className="max-w-xl mx-auto space-y-4 animate-pulse">
-        {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-16 rounded-2xl bg-slate-100" />
+        {SKELETON_KEYS.map((key) => (
+          <div key={key} className="h-16 rounded-2xl bg-slate-100" />
         ))}
       </div>
     );
   }
 
   const { person } = me;
-  const displayName = person
-    ? `${person.givenName} ${person.surname}`
-    : me.email;
+  const displayName = person ? `${person.givenName} ${person.surname}` : me.email;
   const initials = person
     ? `${person.givenName[0]}${person.surname[0]}`.toUpperCase()
     : me.email[0].toUpperCase();
@@ -152,36 +146,12 @@ export default function ProfilePage() {
         <Row icon={<ShieldIcon />} label="Roll" value={ROLE_LABELS[me.role]} />
         {person ? (
           <>
-            <Row
-              icon={<BadgeIcon />}
-              label="Eesnimi"
-              value={person.givenName}
-            />
-            <Row
-              icon={<BadgeIcon />}
-              label="Perekonnanimi"
-              value={person.surname}
-            />
-            <Row
-              icon={<FingerprintIcon />}
-              label="Isikukood"
-              value={person.socialSecurityNumber}
-            />
-            <Row
-              icon={<WorkIcon />}
-              label="Ametinimetus"
-              value={person.jobTitle}
-            />
-            <Row
-              icon={<AccountTreeIcon />}
-              label="Osakond"
-              value={person.department}
-            />
-            <Row
-              icon={<BusinessIcon />}
-              label="Organisatsioon"
-              value={person.organization}
-            />
+            <Row icon={<BadgeIcon />} label="Eesnimi" value={person.givenName} />
+            <Row icon={<BadgeIcon />} label="Perekonnanimi" value={person.surname} />
+            <Row icon={<FingerprintIcon />} label="Isikukood" value={person.socialSecurityNumber} />
+            <Row icon={<WorkIcon />} label="Ametinimetus" value={person.jobTitle} />
+            <Row icon={<AccountTreeIcon />} label="Osakond" value={person.department} />
+            <Row icon={<BusinessIcon />} label="Organisatsioon" value={person.organization} />
           </>
         ) : (
           <div className="px-6 py-4 text-sm text-slate-400">
@@ -199,10 +169,11 @@ export default function ProfilePage() {
 
         <form onSubmit={handleSave} className="space-y-4">
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-slate-700">
+            <label htmlFor="new-email" className="block text-sm font-medium text-slate-700">
               Uus e-post
             </label>
             <input
+              id="new-email"
               type="email"
               value={newEmail}
               onChange={(e) => setNewEmail(e.target.value)}
@@ -219,10 +190,11 @@ export default function ProfilePage() {
           </div>
 
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-slate-700">
+            <label htmlFor="new-password" className="block text-sm font-medium text-slate-700">
               Uus parool
             </label>
             <input
+              id="new-password"
               type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
@@ -233,10 +205,11 @@ export default function ProfilePage() {
 
           {newPassword && (
             <div className="space-y-1.5">
-              <label className="block text-sm font-medium text-slate-700">
+              <label htmlFor="confirm-password" className="block text-sm font-medium text-slate-700">
                 Korda parooli
               </label>
               <input
+                id="confirm-password"
                 type="password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
@@ -285,9 +258,7 @@ function Row({
 }) {
   return (
     <div className="flex items-center gap-4 px-6 py-4">
-      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">
-        {icon}
-      </span>
+      <span className="text-slate-400 shrink-0 [&>svg]:text-[20px]">{icon}</span>
       <div className="min-w-0">
         <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
           {label}

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -227,7 +227,10 @@ export default function ProfilePage() {
               htmlFor="new-password"
               className="block text-sm font-medium text-slate-700"
             >
-              Uus parool
+              Uus parool{" "}
+              <span className="text-xs font-normal text-slate-400">
+                (vähemalt 1 väike täht, 1 suur täht, 1 erisümbol, vähemalt 8 sümbolit)
+              </span>
             </label>
             <input
               id="new-password"

--- a/app/(protected)/settings/countries/page.tsx
+++ b/app/(protected)/settings/countries/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
+import { countriesApi } from "@/lib/api/admin";
+
+export default function CountriesPage() {
+  return <LookupManagerWrapper title="Halda riike" backHref="/settings" api={countriesApi} />;
+}

--- a/app/(protected)/settings/countries/page.tsx
+++ b/app/(protected)/settings/countries/page.tsx
@@ -4,5 +4,11 @@ import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
 import { countriesApi } from "@/lib/api/admin";
 
 export default function CountriesPage() {
-  return <LookupManagerWrapper title="Halda riike" backHref="/settings" api={countriesApi} />;
+  return (
+    <LookupManagerWrapper
+      title="Halda riike"
+      backHref="/settings"
+      api={countriesApi}
+    />
+  );
 }

--- a/app/(protected)/settings/departments/page.tsx
+++ b/app/(protected)/settings/departments/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
+import { departmentsApi } from "@/lib/api/admin";
+
+export default function DepartmentsPage() {
+  return <LookupManagerWrapper title="Halda osakondi" backHref="/settings" api={departmentsApi} />;
+}

--- a/app/(protected)/settings/departments/page.tsx
+++ b/app/(protected)/settings/departments/page.tsx
@@ -4,5 +4,11 @@ import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
 import { departmentsApi } from "@/lib/api/admin";
 
 export default function DepartmentsPage() {
-  return <LookupManagerWrapper title="Halda osakondi" backHref="/settings" api={departmentsApi} />;
+  return (
+    <LookupManagerWrapper
+      title="Halda osakondi"
+      backHref="/settings"
+      api={departmentsApi}
+    />
+  );
 }

--- a/app/(protected)/settings/document-types/page.tsx
+++ b/app/(protected)/settings/document-types/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
+import { documentTypesApi } from "@/lib/api/admin";
+
+export default function DocumentTypesPage() {
+  return <LookupManagerWrapper title="Halda dokumendi tüüpe" backHref="/settings" api={documentTypesApi} />;
+}

--- a/app/(protected)/settings/document-types/page.tsx
+++ b/app/(protected)/settings/document-types/page.tsx
@@ -4,5 +4,11 @@ import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
 import { documentTypesApi } from "@/lib/api/admin";
 
 export default function DocumentTypesPage() {
-  return <LookupManagerWrapper title="Halda dokumendi tüüpe" backHref="/settings" api={documentTypesApi} />;
+  return (
+    <LookupManagerWrapper
+      title="Halda dokumendi tüüpe"
+      backHref="/settings"
+      api={documentTypesApi}
+    />
+  );
 }

--- a/app/(protected)/settings/organizations/page.tsx
+++ b/app/(protected)/settings/organizations/page.tsx
@@ -4,5 +4,11 @@ import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
 import { organizationsApi } from "@/lib/api/admin";
 
 export default function OrganizationsPage() {
-  return <LookupManagerWrapper title="Halda organisatsioone" backHref="/settings" api={organizationsApi} />;
+  return (
+    <LookupManagerWrapper
+      title="Halda organisatsioone"
+      backHref="/settings"
+      api={organizationsApi}
+    />
+  );
 }

--- a/app/(protected)/settings/organizations/page.tsx
+++ b/app/(protected)/settings/organizations/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
+import { organizationsApi } from "@/lib/api/admin";
+
+export default function OrganizationsPage() {
+  return <LookupManagerWrapper title="Halda organisatsioone" backHref="/settings" api={organizationsApi} />;
+}

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import PublicIcon from "@mui/icons-material/Public";
+import BusinessIcon from "@mui/icons-material/Business";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import ShieldIcon from "@mui/icons-material/Shield";
+import BadgeIcon from "@mui/icons-material/Badge";
+import PeopleIcon from "@mui/icons-material/People";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+
+const sections = [
+  {
+    href: "/settings/users",
+    icon: <PeopleIcon className="text-blue-700 !text-2xl" />,
+    title: "Halda rakenduse kasutajaid",
+    description: "Lisa, muuda või kustuta rakenduse kasutajakontosid.",
+  },
+  {
+    href: "/settings/countries",
+    icon: <PublicIcon className="text-blue-700 !text-2xl" />,
+    title: "Halda riike",
+    description: "Lisa, muuda või kustuta riikide kirjeid.",
+  },
+  {
+    href: "/settings/organizations",
+    icon: <BusinessIcon className="text-blue-700 !text-2xl" />,
+    title: "Halda organisatsioone",
+    description: "Lisa, muuda või kustuta organisatsioonide kirjeid.",
+  },
+  {
+    href: "/settings/departments",
+    icon: <AccountTreeIcon className="text-blue-700 !text-2xl" />,
+    title: "Halda osakondi",
+    description: "Lisa, muuda või kustuta osakondade kirjeid.",
+  },
+  {
+    href: "/settings/roles",
+    icon: <ShieldIcon className="text-blue-700 !text-2xl" />,
+    title: "Halda rolle",
+    description: "Lisa, muuda või kustuta rollide kirjeid.",
+  },
+  {
+    href: "/settings/document-types",
+    icon: <BadgeIcon className="text-blue-700 !text-2xl" />,
+    title: "Halda dokumendi tüüpe",
+    description: "Lisa, muuda või kustuta dokumendi tüüpide kirjeid.",
+  },
+];
+
+export default function AdminSettingsPage() {
+  return (
+    <div className="max-w-2xl mx-auto space-y-6 animate-in fade-in duration-500">
+      <div>
+        <h2 className="text-2xl font-black text-slate-900 tracking-tight">
+          Admin seadistused
+        </h2>
+        <p className="text-sm text-slate-500 mt-1">
+          Halda süsteemi otsingutabeleid ja põhiandmeid.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm divide-y divide-slate-100 overflow-hidden">
+        {sections.map((s) => (
+          <Link
+            key={s.href}
+            href={s.href}
+            className="flex items-center gap-4 px-6 py-5 hover:bg-slate-50 transition-colors group"
+          >
+            <div className="size-10 rounded-xl bg-blue-50 flex items-center justify-center shrink-0">
+              {s.icon}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-bold text-slate-900">{s.title}</p>
+              <p className="text-xs text-slate-500 mt-0.5">{s.description}</p>
+            </div>
+            <ChevronRightIcon className="text-slate-300 group-hover:text-slate-500 transition-colors !text-xl shrink-0" />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/settings/roles/page.tsx
+++ b/app/(protected)/settings/roles/page.tsx
@@ -4,5 +4,11 @@ import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
 import { rolesApi } from "@/lib/api/admin";
 
 export default function RolesPage() {
-  return <LookupManagerWrapper title="Halda rolle" backHref="/settings" api={rolesApi} />;
+  return (
+    <LookupManagerWrapper
+      title="Halda rolle"
+      backHref="/settings"
+      api={rolesApi}
+    />
+  );
 }

--- a/app/(protected)/settings/roles/page.tsx
+++ b/app/(protected)/settings/roles/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { LookupManagerWrapper } from "@/components/admin/LookupManagerWrapper";
+import { rolesApi } from "@/lib/api/admin";
+
+export default function RolesPage() {
+  return <LookupManagerWrapper title="Halda rolle" backHref="/settings" api={rolesApi} />;
+}

--- a/app/(protected)/settings/users/page.tsx
+++ b/app/(protected)/settings/users/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Link from "next/link";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { UserManager } from "@/components/admin/UserManager";
+
+export default function UsersPage() {
+  return (
+    <div className="max-w-2xl mx-auto space-y-6 animate-in fade-in duration-500">
+      <div className="flex items-center gap-3">
+        <Link
+          href="/settings"
+          className="flex items-center justify-center size-9 rounded-lg border border-slate-200 text-slate-500 hover:bg-slate-50 hover:text-slate-900 transition-colors"
+          title="Tagasi"
+        >
+          <ChevronLeftIcon className="!text-xl" />
+        </Link>
+        <h2 className="text-2xl font-black text-slate-900 tracking-tight">
+          Halda rakenduse kasutajaid
+        </h2>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
+        <UserManager />
+      </div>
+    </div>
+  );
+}

--- a/components/admin/LookupManager.tsx
+++ b/components/admin/LookupManager.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import { type LookupRecord } from "@/lib/api/admin";
+import { ApiError } from "@/lib/apiClient";
+
+interface Api {
+  list(): Promise<LookupRecord[]>;
+  create(name: string): Promise<LookupRecord>;
+  update(id: string, name: string): Promise<LookupRecord>;
+  remove(id: string): Promise<void>;
+}
+
+interface Props {
+  readonly api: Api;
+}
+
+export function LookupManager({ api }: Props) {
+  const [records, setRecords] = useState<LookupRecord[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Add form
+  const [addName, setAddName] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  // Inline edit
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  // Delete
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const addInputRef = useRef<HTMLInputElement>(null);
+  const addInputId = useId();
+
+  useEffect(() => {
+    api
+      .list()
+      .then(setRecords)
+      .catch((err) => {
+        if (err instanceof ApiError) setLoadError(err.message);
+      });
+  }, [api]);
+
+  const handleAdd = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const name = addName.trim();
+    if (!name) return;
+    setAddError(null);
+    setIsAdding(true);
+    try {
+      const created = await api.create(name);
+      setRecords((prev) => [...prev, created]);
+      setAddName("");
+      addInputRef.current?.focus();
+    } catch (err) {
+      setAddError(err instanceof ApiError ? err.message : "Viga lisamisel.");
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const startEdit = (record: LookupRecord) => {
+    setEditId(record.id);
+    setEditName(record.name);
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditId(null);
+    setEditError(null);
+  };
+
+  const handleSaveEdit = async (id: string) => {
+    const name = editName.trim();
+    if (!name) return;
+    setEditError(null);
+    setIsSavingEdit(true);
+    try {
+      const updated = await api.update(id, name);
+      setRecords((prev) => prev.map((r) => (r.id === id ? updated : r)));
+      setEditId(null);
+    } catch (err) {
+      setEditError(err instanceof ApiError ? err.message : "Viga salvestamisel.");
+    } finally {
+      setIsSavingEdit(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    try {
+      await api.remove(id);
+      setRecords((prev) => prev.filter((r) => r.id !== id));
+    } catch (err) {
+      // Re-surface delete errors via edit error slot for visibility
+      setEditError(err instanceof ApiError ? err.message : "Viga kustutamisel.");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <p className="text-sm font-semibold text-rose-600 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+        {loadError}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Add form */}
+      <form onSubmit={handleAdd} className="flex gap-2">
+        <div className="flex-1 space-y-1">
+          <label htmlFor={addInputId} className="sr-only">
+            Uue kirje nimi
+          </label>
+          <input
+            id={addInputId}
+            ref={addInputRef}
+            type="text"
+            value={addName}
+            onChange={(e) => setAddName(e.target.value)}
+            placeholder="Uue kirje nimi…"
+            maxLength={255}
+            className="w-full px-3 py-2.5 rounded-lg border border-slate-200 bg-white text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-600/20 focus:border-blue-600 transition"
+          />
+          {addError && (
+            <p className="text-xs font-semibold text-rose-600">{addError}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={isAdding || !addName.trim()}
+          className="flex items-center gap-1.5 px-4 py-2.5 bg-blue-700 hover:bg-blue-800 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors"
+        >
+          <AddIcon className="!text-base" />
+          Lisa
+        </button>
+      </form>
+
+      {/* Records list */}
+      {editError && (
+        <p className="text-sm font-semibold text-rose-600 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+          {editError}
+        </p>
+      )}
+
+      <div className="rounded-2xl border border-slate-200 overflow-hidden">
+        {records.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-slate-400 text-center">
+            Kirjeid ei ole.
+          </p>
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {records.map((record) => (
+              <li key={record.id} className="flex items-center gap-3 px-4 py-3 bg-white hover:bg-slate-50 transition-colors">
+                {editId === record.id ? (
+                  <>
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleSaveEdit(record.id);
+                        if (e.key === "Escape") cancelEdit();
+                      }}
+                      autoFocus
+                      maxLength={255}
+                      className="flex-1 px-3 py-1.5 rounded-lg border border-blue-400 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-600/20"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleSaveEdit(record.id)}
+                      disabled={isSavingEdit || !editName.trim()}
+                      className="p-1.5 text-emerald-600 hover:bg-emerald-50 rounded-lg disabled:opacity-50 transition-colors"
+                      title="Salvesta"
+                    >
+                      <CheckIcon className="!text-base" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      className="p-1.5 text-slate-400 hover:bg-slate-100 rounded-lg transition-colors"
+                      title="Tühista"
+                    >
+                      <CloseIcon className="!text-base" />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span className="flex-1 text-sm font-medium text-slate-800">
+                      {record.name}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => startEdit(record)}
+                      className="p-1.5 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                      title="Muuda"
+                    >
+                      <EditIcon className="!text-base" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(record.id)}
+                      disabled={deletingId === record.id}
+                      className="p-1.5 text-slate-400 hover:text-rose-600 hover:bg-rose-50 rounded-lg disabled:opacity-50 transition-colors"
+                      title="Kustuta"
+                    >
+                      <DeleteIcon className="!text-base" />
+                    </button>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/LookupManager.tsx
+++ b/components/admin/LookupManager.tsx
@@ -89,7 +89,9 @@ export function LookupManager({ api }: Props) {
       setRecords((prev) => prev.map((r) => (r.id === id ? updated : r)));
       setEditId(null);
     } catch (err) {
-      setEditError(err instanceof ApiError ? err.message : "Viga salvestamisel.");
+      setEditError(
+        err instanceof ApiError ? err.message : "Viga salvestamisel.",
+      );
     } finally {
       setIsSavingEdit(false);
     }
@@ -102,7 +104,9 @@ export function LookupManager({ api }: Props) {
       setRecords((prev) => prev.filter((r) => r.id !== id));
     } catch (err) {
       // Re-surface delete errors via edit error slot for visibility
-      setEditError(err instanceof ApiError ? err.message : "Viga kustutamisel.");
+      setEditError(
+        err instanceof ApiError ? err.message : "Viga kustutamisel.",
+      );
     } finally {
       setDeletingId(null);
     }
@@ -163,7 +167,10 @@ export function LookupManager({ api }: Props) {
         ) : (
           <ul className="divide-y divide-slate-100">
             {records.map((record) => (
-              <li key={record.id} className="flex items-center gap-3 px-4 py-3 bg-white hover:bg-slate-50 transition-colors">
+              <li
+                key={record.id}
+                className="flex items-center gap-3 px-4 py-3 bg-white hover:bg-slate-50 transition-colors"
+              >
                 {editId === record.id ? (
                   <>
                     <input

--- a/components/admin/LookupManagerWrapper.tsx
+++ b/components/admin/LookupManagerWrapper.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { LookupManager } from "@/components/admin/LookupManager";
+import type { LookupRecord } from "@/lib/api/admin";
+
+interface Api {
+  list(): Promise<LookupRecord[]>;
+  create(name: string): Promise<LookupRecord>;
+  update(id: string, name: string): Promise<LookupRecord>;
+  remove(id: string): Promise<void>;
+}
+
+interface Props {
+  readonly title: string;
+  readonly backHref: string;
+  readonly api: Api;
+}
+
+export function LookupManagerWrapper({ title, backHref, api }: Props) {
+  return (
+    <div className="max-w-2xl mx-auto space-y-6 animate-in fade-in duration-500">
+      <div className="flex items-center gap-3">
+        <Link
+          href={backHref}
+          className="flex items-center justify-center size-9 rounded-lg border border-slate-200 text-slate-500 hover:bg-slate-50 hover:text-slate-900 transition-colors"
+          title="Tagasi"
+        >
+          <ChevronLeftIcon className="!text-xl" />
+        </Link>
+        <h2 className="text-2xl font-black text-slate-900 tracking-tight">
+          {title}
+        </h2>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
+        <LookupManager api={api} />
+      </div>
+    </div>
+  );
+}

--- a/components/admin/UserManager.tsx
+++ b/components/admin/UserManager.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import PersonIcon from "@mui/icons-material/Person";
+import { adminUsersApi, type AdminUserResponse, type UserRole } from "@/lib/api/adminUsers";
+import { ApiError } from "@/lib/apiClient";
+
+const ROLES: UserRole[] = ["VISITOR", "RECEPTIONIST", "SECURITY_CHIEF", "ADMIN"];
+
+const ROLE_LABELS: Record<UserRole, string> = {
+  VISITOR: "Külastaja",
+  RECEPTIONIST: "Administraator",
+  SECURITY_CHIEF: "Turvaülem",
+  ADMIN: "Süsteemiadmin",
+};
+
+const inputCls =
+  "w-full px-3 py-2.5 rounded-lg border border-slate-200 bg-white text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-600/20 focus:border-blue-600 transition";
+
+function validatePassword(password: string): string | null {
+  if (password.length < 8) return "Parool peab olema vähemalt 8 tähemärki pikk.";
+  if (!/[A-Z]/.test(password)) return "Parool peab sisaldama vähemalt ühte suurtähte.";
+  if (!/[a-z]/.test(password)) return "Parool peab sisaldama vähemalt ühte väiketähte.";
+  if (!/[^A-Za-z0-9]/.test(password)) return "Parool peab sisaldama vähemalt ühte erimärki.";
+  return null;
+}
+
+export function UserManager() {
+  const [users, setUsers] = useState<AdminUserResponse[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Add form
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addEmail, setAddEmail] = useState("");
+  const [addPassword, setAddPassword] = useState("");
+  const [addRole, setAddRole] = useState<UserRole>("VISITOR");
+  const [isAdding, setIsAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  // Edit
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editEmail, setEditEmail] = useState("");
+  const [editPassword, setEditPassword] = useState("");
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  // Delete
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const emailId = useId();
+  const passwordId = useId();
+  const roleId = useId();
+
+  useEffect(() => {
+    adminUsersApi
+      .list()
+      .then(setUsers)
+      .catch((err) => {
+        if (err instanceof ApiError) setLoadError(err.message);
+      });
+  }, []);
+
+  const handleAdd = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setAddError(null);
+    const pwError = validatePassword(addPassword);
+    if (pwError) { setAddError(pwError); return; }
+
+    setIsAdding(true);
+    try {
+      const created = await adminUsersApi.create({ email: addEmail, password: addPassword, role: addRole });
+      setUsers((prev) => [...prev, created]);
+      setAddEmail("");
+      setAddPassword("");
+      setAddRole("VISITOR");
+      setShowAddForm(false);
+    } catch (err) {
+      setAddError(err instanceof ApiError ? err.message : "Viga lisamisel.");
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const startEdit = (user: AdminUserResponse) => {
+    setEditId(user.id);
+    setEditEmail(user.email);
+    setEditPassword("");
+    setEditError(null);
+  };
+
+  const cancelEdit = () => { setEditId(null); setEditError(null); };
+
+  const handleSaveEdit = async (id: string) => {
+    setEditError(null);
+    if (!editEmail && !editPassword) {
+      setEditError("Sisesta uus e-post ja/või parool.");
+      return;
+    }
+    if (editPassword) {
+      const pwError = validatePassword(editPassword);
+      if (pwError) { setEditError(pwError); return; }
+    }
+    const body: { email?: string; password?: string } = {};
+    if (editEmail) body.email = editEmail;
+    if (editPassword) body.password = editPassword;
+
+    setIsSavingEdit(true);
+    try {
+      const updated = await adminUsersApi.update(id, body);
+      setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));
+      setEditId(null);
+    } catch (err) {
+      setEditError(err instanceof ApiError ? err.message : "Viga salvestamisel.");
+    } finally {
+      setIsSavingEdit(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    try {
+      await adminUsersApi.remove(id);
+      setUsers((prev) => prev.filter((u) => u.id !== id));
+    } catch (err) {
+      setEditError(err instanceof ApiError ? err.message : "Viga kustutamisel.");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <p className="text-sm font-semibold text-rose-600 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+        {loadError}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Add button / form */}
+      {showAddForm ? (
+        <form onSubmit={handleAdd} className="rounded-xl border border-blue-200 bg-blue-50/50 p-4 space-y-3">
+          <p className="text-sm font-bold text-slate-800">Uus kasutaja</p>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label htmlFor={emailId} className="block text-xs font-medium text-slate-600">E-post *</label>
+              <input id={emailId} type="email" value={addEmail} onChange={(e) => setAddEmail(e.target.value)}
+                placeholder="kasutaja@näide.ee" maxLength={255} required className={inputCls} />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor={roleId} className="block text-xs font-medium text-slate-600">Roll</label>
+              <select id={roleId} value={addRole} onChange={(e) => setAddRole(e.target.value as UserRole)} className={inputCls}>
+                {ROLES.map((r) => <option key={r} value={r}>{ROLE_LABELS[r]}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor={passwordId} className="block text-xs font-medium text-slate-600">Parool *</label>
+            <input id={passwordId} type="password" value={addPassword} onChange={(e) => setAddPassword(e.target.value)}
+              placeholder="Vähemalt 8 tähemärki, suur- ja väiketäht, erimärk" required className={inputCls} />
+          </div>
+
+          {addError && (
+            <p className="text-xs font-semibold text-rose-600">{addError}</p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={() => { setShowAddForm(false); setAddError(null); }}
+              className="px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 rounded-lg transition-colors">
+              Tühista
+            </button>
+            <button type="submit" disabled={isAdding}
+              className="flex items-center gap-1.5 px-4 py-2 bg-blue-700 hover:bg-blue-800 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors">
+              <AddIcon className="!text-base" /> Lisa kasutaja
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button type="button" onClick={() => setShowAddForm(true)}
+          className="flex items-center gap-1.5 px-4 py-2.5 bg-blue-700 hover:bg-blue-800 text-white text-sm font-bold rounded-lg transition-colors">
+          <AddIcon className="!text-base" /> Lisa kasutaja
+        </button>
+      )}
+
+      {editError && (
+        <p className="text-sm font-semibold text-rose-600 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+          {editError}
+        </p>
+      )}
+
+      {/* User list */}
+      <div className="rounded-2xl border border-slate-200 overflow-hidden">
+        {users.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-slate-400 text-center">Kasutajaid ei ole.</p>
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {users.map((user) => (
+              <li key={user.id} className="bg-white hover:bg-slate-50 transition-colors">
+                {editId === user.id ? (
+                  <div className="px-4 py-3 space-y-3">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Muuda kasutajat</p>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1">
+                        <label className="block text-xs font-medium text-slate-600">Uus e-post</label>
+                        <input type="email" value={editEmail} onChange={(e) => setEditEmail(e.target.value)}
+                          maxLength={255} className={inputCls} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="block text-xs font-medium text-slate-600">Uus parool</label>
+                        <input type="password" value={editPassword} onChange={(e) => setEditPassword(e.target.value)}
+                          placeholder="Jäta tühjaks, kui ei muuda" className={inputCls} />
+                      </div>
+                    </div>
+                    {editError && <p className="text-xs font-semibold text-rose-600">{editError}</p>}
+                    <div className="flex justify-end gap-2">
+                      <button type="button" onClick={cancelEdit}
+                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 rounded-lg transition-colors">
+                        <CloseIcon className="!text-base" /> Tühista
+                      </button>
+                      <button type="button" onClick={() => handleSaveEdit(user.id)} disabled={isSavingEdit}
+                        className="flex items-center gap-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors">
+                        <CheckIcon className="!text-base" /> Salvesta
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-3 px-4 py-3">
+                    <div className="size-9 rounded-lg bg-slate-100 text-slate-500 flex items-center justify-center shrink-0">
+                      <PersonIcon className="!text-base" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-slate-900 truncate">
+                        {user.person
+                          ? `${user.person.givenName} ${user.person.surname}`
+                          : user.email}
+                      </p>
+                      <p className="text-xs text-slate-400 truncate">
+                        {user.person ? user.email + " · " : ""}{ROLE_LABELS[user.role]}
+                      </p>
+                    </div>
+                    <button type="button" onClick={() => startEdit(user)}
+                      className="p-1.5 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors" title="Muuda">
+                      <EditIcon className="!text-base" />
+                    </button>
+                    <button type="button" onClick={() => handleDelete(user.id)} disabled={deletingId === user.id}
+                      className="p-1.5 text-slate-400 hover:text-rose-600 hover:bg-rose-50 rounded-lg disabled:opacity-50 transition-colors" title="Kustuta">
+                      <DeleteIcon className="!text-base" />
+                    </button>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/UserManager.tsx
+++ b/components/admin/UserManager.tsx
@@ -7,10 +7,19 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 import PersonIcon from "@mui/icons-material/Person";
-import { adminUsersApi, type AdminUserResponse, type UserRole } from "@/lib/api/adminUsers";
+import {
+  adminUsersApi,
+  type AdminUserResponse,
+  type UserRole,
+} from "@/lib/api/adminUsers";
 import { ApiError } from "@/lib/apiClient";
 
-const ROLES: UserRole[] = ["VISITOR", "RECEPTIONIST", "SECURITY_CHIEF", "ADMIN"];
+const ROLES: UserRole[] = [
+  "VISITOR",
+  "RECEPTIONIST",
+  "SECURITY_CHIEF",
+  "ADMIN",
+];
 
 const ROLE_LABELS: Record<UserRole, string> = {
   VISITOR: "Külastaja",
@@ -23,10 +32,14 @@ const inputCls =
   "w-full px-3 py-2.5 rounded-lg border border-slate-200 bg-white text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-600/20 focus:border-blue-600 transition";
 
 function validatePassword(password: string): string | null {
-  if (password.length < 8) return "Parool peab olema vähemalt 8 tähemärki pikk.";
-  if (!/[A-Z]/.test(password)) return "Parool peab sisaldama vähemalt ühte suurtähte.";
-  if (!/[a-z]/.test(password)) return "Parool peab sisaldama vähemalt ühte väiketähte.";
-  if (!/[^A-Za-z0-9]/.test(password)) return "Parool peab sisaldama vähemalt ühte erimärki.";
+  if (password.length < 8)
+    return "Parool peab olema vähemalt 8 tähemärki pikk.";
+  if (!/[A-Z]/.test(password))
+    return "Parool peab sisaldama vähemalt ühte suurtähte.";
+  if (!/[a-z]/.test(password))
+    return "Parool peab sisaldama vähemalt ühte väiketähte.";
+  if (!/[^A-Za-z0-9]/.test(password))
+    return "Parool peab sisaldama vähemalt ühte erimärki.";
   return null;
 }
 
@@ -69,11 +82,18 @@ export function UserManager() {
     e.preventDefault();
     setAddError(null);
     const pwError = validatePassword(addPassword);
-    if (pwError) { setAddError(pwError); return; }
+    if (pwError) {
+      setAddError(pwError);
+      return;
+    }
 
     setIsAdding(true);
     try {
-      const created = await adminUsersApi.create({ email: addEmail, password: addPassword, role: addRole });
+      const created = await adminUsersApi.create({
+        email: addEmail,
+        password: addPassword,
+        role: addRole,
+      });
       setUsers((prev) => [...prev, created]);
       setAddEmail("");
       setAddPassword("");
@@ -93,7 +113,10 @@ export function UserManager() {
     setEditError(null);
   };
 
-  const cancelEdit = () => { setEditId(null); setEditError(null); };
+  const cancelEdit = () => {
+    setEditId(null);
+    setEditError(null);
+  };
 
   const handleSaveEdit = async (id: string) => {
     setEditError(null);
@@ -103,7 +126,10 @@ export function UserManager() {
     }
     if (editPassword) {
       const pwError = validatePassword(editPassword);
-      if (pwError) { setEditError(pwError); return; }
+      if (pwError) {
+        setEditError(pwError);
+        return;
+      }
     }
     const body: { email?: string; password?: string } = {};
     if (editEmail) body.email = editEmail;
@@ -115,7 +141,9 @@ export function UserManager() {
       setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));
       setEditId(null);
     } catch (err) {
-      setEditError(err instanceof ApiError ? err.message : "Viga salvestamisel.");
+      setEditError(
+        err instanceof ApiError ? err.message : "Viga salvestamisel.",
+      );
     } finally {
       setIsSavingEdit(false);
     }
@@ -127,7 +155,9 @@ export function UserManager() {
       await adminUsersApi.remove(id);
       setUsers((prev) => prev.filter((u) => u.id !== id));
     } catch (err) {
-      setEditError(err instanceof ApiError ? err.message : "Viga kustutamisel.");
+      setEditError(
+        err instanceof ApiError ? err.message : "Viga kustutamisel.",
+      );
     } finally {
       setDeletingId(null);
     }
@@ -145,27 +175,69 @@ export function UserManager() {
     <div className="space-y-4">
       {/* Add button / form */}
       {showAddForm ? (
-        <form onSubmit={handleAdd} className="rounded-xl border border-blue-200 bg-blue-50/50 p-4 space-y-3">
+        <form
+          onSubmit={handleAdd}
+          className="rounded-xl border border-blue-200 bg-blue-50/50 p-4 space-y-3"
+        >
           <p className="text-sm font-bold text-slate-800">Uus kasutaja</p>
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
-              <label htmlFor={emailId} className="block text-xs font-medium text-slate-600">E-post *</label>
-              <input id={emailId} type="email" value={addEmail} onChange={(e) => setAddEmail(e.target.value)}
-                placeholder="kasutaja@näide.ee" maxLength={255} required className={inputCls} />
+              <label
+                htmlFor={emailId}
+                className="block text-xs font-medium text-slate-600"
+              >
+                E-post *
+              </label>
+              <input
+                id={emailId}
+                type="email"
+                value={addEmail}
+                onChange={(e) => setAddEmail(e.target.value)}
+                placeholder="kasutaja@näide.ee"
+                maxLength={255}
+                required
+                className={inputCls}
+              />
             </div>
             <div className="space-y-1">
-              <label htmlFor={roleId} className="block text-xs font-medium text-slate-600">Roll</label>
-              <select id={roleId} value={addRole} onChange={(e) => setAddRole(e.target.value as UserRole)} className={inputCls}>
-                {ROLES.map((r) => <option key={r} value={r}>{ROLE_LABELS[r]}</option>)}
+              <label
+                htmlFor={roleId}
+                className="block text-xs font-medium text-slate-600"
+              >
+                Roll
+              </label>
+              <select
+                id={roleId}
+                value={addRole}
+                onChange={(e) => setAddRole(e.target.value as UserRole)}
+                className={inputCls}
+              >
+                {ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {ROLE_LABELS[r]}
+                  </option>
+                ))}
               </select>
             </div>
           </div>
 
           <div className="space-y-1">
-            <label htmlFor={passwordId} className="block text-xs font-medium text-slate-600">Parool *</label>
-            <input id={passwordId} type="password" value={addPassword} onChange={(e) => setAddPassword(e.target.value)}
-              placeholder="Vähemalt 8 tähemärki, suur- ja väiketäht, erimärk" required className={inputCls} />
+            <label
+              htmlFor={passwordId}
+              className="block text-xs font-medium text-slate-600"
+            >
+              Parool *
+            </label>
+            <input
+              id={passwordId}
+              type="password"
+              value={addPassword}
+              onChange={(e) => setAddPassword(e.target.value)}
+              placeholder="Vähemalt 8 tähemärki, suur- ja väiketäht, erimärk"
+              required
+              className={inputCls}
+            />
           </div>
 
           {addError && (
@@ -173,19 +245,31 @@ export function UserManager() {
           )}
 
           <div className="flex justify-end gap-2">
-            <button type="button" onClick={() => { setShowAddForm(false); setAddError(null); }}
-              className="px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 rounded-lg transition-colors">
+            <button
+              type="button"
+              onClick={() => {
+                setShowAddForm(false);
+                setAddError(null);
+              }}
+              className="px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
+            >
               Tühista
             </button>
-            <button type="submit" disabled={isAdding}
-              className="flex items-center gap-1.5 px-4 py-2 bg-blue-700 hover:bg-blue-800 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors">
+            <button
+              type="submit"
+              disabled={isAdding}
+              className="flex items-center gap-1.5 px-4 py-2 bg-blue-700 hover:bg-blue-800 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors"
+            >
               <AddIcon className="!text-base" /> Lisa kasutaja
             </button>
           </div>
         </form>
       ) : (
-        <button type="button" onClick={() => setShowAddForm(true)}
-          className="flex items-center gap-1.5 px-4 py-2.5 bg-blue-700 hover:bg-blue-800 text-white text-sm font-bold rounded-lg transition-colors">
+        <button
+          type="button"
+          onClick={() => setShowAddForm(true)}
+          className="flex items-center gap-1.5 px-4 py-2.5 bg-blue-700 hover:bg-blue-800 text-white text-sm font-bold rounded-lg transition-colors"
+        >
           <AddIcon className="!text-base" /> Lisa kasutaja
         </button>
       )}
@@ -199,11 +283,16 @@ export function UserManager() {
       {/* User list */}
       <div className="rounded-2xl border border-slate-200 overflow-hidden">
         {users.length === 0 ? (
-          <p className="px-6 py-8 text-sm text-slate-400 text-center">Kasutajaid ei ole.</p>
+          <p className="px-6 py-8 text-sm text-slate-400 text-center">
+            Kasutajaid ei ole.
+          </p>
         ) : (
           <ul className="divide-y divide-slate-100">
             {users.map((user) => (
-              <li key={user.id} className="bg-white hover:bg-slate-50 transition-colors">
+              <li
+                key={user.id}
+                className="bg-white hover:bg-slate-50 transition-colors"
+              >
                 {editId === user.id ? (
                   <EditUserForm
                     email={editEmail}
@@ -227,15 +316,25 @@ export function UserManager() {
                           : user.email}
                       </p>
                       <p className="text-xs text-slate-400 truncate">
-                        {user.person ? user.email + " · " : ""}{ROLE_LABELS[user.role]}
+                        {user.person ? user.email + " · " : ""}
+                        {ROLE_LABELS[user.role]}
                       </p>
                     </div>
-                    <button type="button" onClick={() => startEdit(user)}
-                      className="p-1.5 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors" title="Muuda">
+                    <button
+                      type="button"
+                      onClick={() => startEdit(user)}
+                      className="p-1.5 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                      title="Muuda"
+                    >
                       <EditIcon className="!text-base" />
                     </button>
-                    <button type="button" onClick={() => handleDelete(user.id)} disabled={deletingId === user.id}
-                      className="p-1.5 text-slate-400 hover:text-rose-600 hover:bg-rose-50 rounded-lg disabled:opacity-50 transition-colors" title="Kustuta">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(user.id)}
+                      disabled={deletingId === user.id}
+                      className="p-1.5 text-slate-400 hover:text-rose-600 hover:bg-rose-50 rounded-lg disabled:opacity-50 transition-colors"
+                      title="Kustuta"
+                    >
                       <DeleteIcon className="!text-base" />
                     </button>
                   </div>
@@ -260,33 +359,73 @@ interface EditUserFormProps {
   readonly onCancel: () => void;
 }
 
-function EditUserForm({ email, password, error, isSaving, onEmailChange, onPasswordChange, onSave, onCancel }: EditUserFormProps) {
+function EditUserForm({
+  email,
+  password,
+  error,
+  isSaving,
+  onEmailChange,
+  onPasswordChange,
+  onSave,
+  onCancel,
+}: EditUserFormProps) {
   const editEmailId = useId();
   const editPasswordId = useId();
 
   return (
     <div className="px-4 py-3 space-y-3">
-      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Muuda kasutajat</p>
+      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+        Muuda kasutajat
+      </p>
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">
-          <label htmlFor={editEmailId} className="block text-xs font-medium text-slate-600">Uus e-post</label>
-          <input id={editEmailId} type="email" value={email} onChange={(e) => onEmailChange(e.target.value)}
-            maxLength={255} className={inputCls} />
+          <label
+            htmlFor={editEmailId}
+            className="block text-xs font-medium text-slate-600"
+          >
+            Uus e-post
+          </label>
+          <input
+            id={editEmailId}
+            type="email"
+            value={email}
+            onChange={(e) => onEmailChange(e.target.value)}
+            maxLength={255}
+            className={inputCls}
+          />
         </div>
         <div className="space-y-1">
-          <label htmlFor={editPasswordId} className="block text-xs font-medium text-slate-600">Uus parool</label>
-          <input id={editPasswordId} type="password" value={password} onChange={(e) => onPasswordChange(e.target.value)}
-            placeholder="Jäta tühjaks, kui ei muuda" className={inputCls} />
+          <label
+            htmlFor={editPasswordId}
+            className="block text-xs font-medium text-slate-600"
+          >
+            Uus parool
+          </label>
+          <input
+            id={editPasswordId}
+            type="password"
+            value={password}
+            onChange={(e) => onPasswordChange(e.target.value)}
+            placeholder="Jäta tühjaks, kui ei muuda"
+            className={inputCls}
+          />
         </div>
       </div>
       {error && <p className="text-xs font-semibold text-rose-600">{error}</p>}
       <div className="flex justify-end gap-2">
-        <button type="button" onClick={onCancel}
-          className="flex items-center gap-1 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 rounded-lg transition-colors">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 rounded-lg transition-colors"
+        >
           <CloseIcon className="!text-base" /> Tühista
         </button>
-        <button type="button" onClick={onSave} disabled={isSaving}
-          className="flex items-center gap-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={isSaving}
+          className="flex items-center gap-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors"
+        >
           <CheckIcon className="!text-base" /> Salvesta
         </button>
       </div>

--- a/components/admin/UserManager.tsx
+++ b/components/admin/UserManager.tsx
@@ -205,32 +205,16 @@ export function UserManager() {
             {users.map((user) => (
               <li key={user.id} className="bg-white hover:bg-slate-50 transition-colors">
                 {editId === user.id ? (
-                  <div className="px-4 py-3 space-y-3">
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Muuda kasutajat</p>
-                    <div className="grid grid-cols-2 gap-3">
-                      <div className="space-y-1">
-                        <label className="block text-xs font-medium text-slate-600">Uus e-post</label>
-                        <input type="email" value={editEmail} onChange={(e) => setEditEmail(e.target.value)}
-                          maxLength={255} className={inputCls} />
-                      </div>
-                      <div className="space-y-1">
-                        <label className="block text-xs font-medium text-slate-600">Uus parool</label>
-                        <input type="password" value={editPassword} onChange={(e) => setEditPassword(e.target.value)}
-                          placeholder="Jäta tühjaks, kui ei muuda" className={inputCls} />
-                      </div>
-                    </div>
-                    {editError && <p className="text-xs font-semibold text-rose-600">{editError}</p>}
-                    <div className="flex justify-end gap-2">
-                      <button type="button" onClick={cancelEdit}
-                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 rounded-lg transition-colors">
-                        <CloseIcon className="!text-base" /> Tühista
-                      </button>
-                      <button type="button" onClick={() => handleSaveEdit(user.id)} disabled={isSavingEdit}
-                        className="flex items-center gap-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors">
-                        <CheckIcon className="!text-base" /> Salvesta
-                      </button>
-                    </div>
-                  </div>
+                  <EditUserForm
+                    email={editEmail}
+                    password={editPassword}
+                    error={editError}
+                    isSaving={isSavingEdit}
+                    onEmailChange={setEditEmail}
+                    onPasswordChange={setEditPassword}
+                    onSave={() => handleSaveEdit(user.id)}
+                    onCancel={cancelEdit}
+                  />
                 ) : (
                   <div className="flex items-center gap-3 px-4 py-3">
                     <div className="size-9 rounded-lg bg-slate-100 text-slate-500 flex items-center justify-center shrink-0">
@@ -260,6 +244,51 @@ export function UserManager() {
             ))}
           </ul>
         )}
+      </div>
+    </div>
+  );
+}
+
+interface EditUserFormProps {
+  readonly email: string;
+  readonly password: string;
+  readonly error: string | null;
+  readonly isSaving: boolean;
+  readonly onEmailChange: (v: string) => void;
+  readonly onPasswordChange: (v: string) => void;
+  readonly onSave: () => void;
+  readonly onCancel: () => void;
+}
+
+function EditUserForm({ email, password, error, isSaving, onEmailChange, onPasswordChange, onSave, onCancel }: EditUserFormProps) {
+  const editEmailId = useId();
+  const editPasswordId = useId();
+
+  return (
+    <div className="px-4 py-3 space-y-3">
+      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Muuda kasutajat</p>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <label htmlFor={editEmailId} className="block text-xs font-medium text-slate-600">Uus e-post</label>
+          <input id={editEmailId} type="email" value={email} onChange={(e) => onEmailChange(e.target.value)}
+            maxLength={255} className={inputCls} />
+        </div>
+        <div className="space-y-1">
+          <label htmlFor={editPasswordId} className="block text-xs font-medium text-slate-600">Uus parool</label>
+          <input id={editPasswordId} type="password" value={password} onChange={(e) => onPasswordChange(e.target.value)}
+            placeholder="Jäta tühjaks, kui ei muuda" className={inputCls} />
+        </div>
+      </div>
+      {error && <p className="text-xs font-semibold text-rose-600">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button type="button" onClick={onCancel}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 rounded-lg transition-colors">
+          <CloseIcon className="!text-base" /> Tühista
+        </button>
+        <button type="button" onClick={onSave} disabled={isSaving}
+          className="flex items-center gap-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-bold rounded-lg transition-colors">
+          <CheckIcon className="!text-base" /> Salvesta
+        </button>
       </div>
     </div>
   );

--- a/components/layout/app-header.tsx
+++ b/components/layout/app-header.tsx
@@ -4,6 +4,7 @@ import ScheduleIcon from "@mui/icons-material/Schedule";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import { Input } from "@/components/ui/input";
 import Image from "next/image";
+import Link from "next/link";
 
 export function AppHeader() {
   return (
@@ -65,15 +66,19 @@ export function AppHeader() {
             <NotificationsIcon className="text-[20px]" />
           </button>
 
-          <div className="h-10 w-10 overflow-hidden rounded-full bg-slate-200 border border-slate-200 dark:border-slate-700">
+          <Link
+            href="/profile"
+            className="h-10 w-10 overflow-hidden rounded-full bg-slate-200 border border-slate-200 dark:border-slate-700 hover:ring-2 hover:ring-primary hover:ring-offset-1 transition-all"
+            title="Minu profiil"
+          >
             <Image
               alt="User Profile"
               src="https://api.dicebear.com/7.x/avataaars/svg?seed=Felix"
-              width={40} // 10 * 4px
-              height={40} // 10 * 4px
+              width={40}
+              height={40}
               className="h-full w-full object-cover"
             />
-          </div>
+          </Link>
         </div>
       </div>
     </header>

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"; // 1. Lisa see rida faili algusesse, et kasutada konksusid
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation"; // 2. Impordi asukoha kontrollija
 import MonitorHeartIcon from "@mui/icons-material/MonitorHeart";
@@ -9,9 +10,17 @@ import KeyIcon from "@mui/icons-material/Key";
 import HistoryIcon from "@mui/icons-material/History";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
+import { getMe } from "@/lib/api/auth";
 
 export function AppSidebar() {
   const pathname = usePathname(); // 3. Haara praegune aadress (nt "/" või "/visitors")
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    getMe()
+      .then((me) => setIsAdmin(me.role === "ADMIN"))
+      .catch(() => setIsAdmin(false));
+  }, []);
 
   // 4. Mugavam on hoida linke massiivis
   const menuItems = [
@@ -74,20 +83,22 @@ export function AppSidebar() {
           );
         })}
 
-        <div className="my-4 h-px bg-slate-100 dark:bg-slate-800" />
-
-        {/* Seadistused eraldi, kui soovid */}
-        <Link
-          href="/settings"
-          className={`flex items-center gap-3 rounded-lg px-3 py-2.5 transition-all ${
-            pathname === "/settings"
-              ? "bg-primary/10 text-primary font-semibold shadow-sm"
-              : "text-slate-600 hover:bg-slate-50 dark:text-slate-400 dark:hover:bg-slate-800"
-          }`}
-        >
-          <SettingsIcon className="text-[20px]" />
-          <span className="text-sm">Seadistused</span>
-        </Link>
+        {isAdmin && (
+          <>
+            <div className="my-4 h-px bg-slate-100 dark:bg-slate-800" />
+            <Link
+              href="/settings"
+              className={`flex items-center gap-3 rounded-lg px-3 py-2.5 transition-all ${
+                pathname === "/settings"
+                  ? "bg-primary/10 text-primary font-semibold shadow-sm"
+                  : "text-slate-600 hover:bg-slate-50 dark:text-slate-400 dark:hover:bg-slate-800"
+              }`}
+            >
+              <SettingsIcon className="text-[20px]" />
+              <span className="text-sm">Seadistused</span>
+            </Link>
+          </>
+        )}
       </nav>
 
       <div className="mt-auto space-y-3">

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -106,9 +106,9 @@ export function AppSidebar() {
         <button
           type="button"
           onClick={() => {
-            localStorage.removeItem("token");
-            document.cookie = "token=; path=/; max-age=0";
-            window.location.href = "/login";
+            globalThis.localStorage.removeItem("token");
+            globalThis.document.cookie = "token=; path=/; max-age=0";
+            globalThis.window.location.href = "/login";
           }}
           className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-slate-600 hover:bg-rose-50 hover:text-rose-600 dark:text-slate-400 dark:hover:bg-rose-900/20 dark:hover:text-rose-400 transition-all"
         >

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -8,6 +8,7 @@ import GroupIcon from "@mui/icons-material/Group";
 import KeyIcon from "@mui/icons-material/Key";
 import HistoryIcon from "@mui/icons-material/History";
 import SettingsIcon from "@mui/icons-material/Settings";
+import LogoutIcon from "@mui/icons-material/Logout";
 
 export function AppSidebar() {
   const pathname = usePathname(); // 3. Haara praegune aadress (nt "/" või "/visitors")
@@ -89,16 +90,31 @@ export function AppSidebar() {
         </Link>
       </nav>
 
-      <div className="mt-auto rounded-xl bg-slate-50 p-4 dark:bg-slate-800 border border-slate-100 dark:border-slate-700">
-        <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
-          Süsteemi olek
-        </p>
-        <div className="mt-2 flex items-center gap-2">
-          <span className="flex h-2 w-2 rounded-full bg-emerald-500 animate-pulse"></span>
-          <p className="text-xs font-semibold text-slate-700 dark:text-slate-300 tracking-tight">
-            Kõik töökorras
+      <div className="mt-auto space-y-3">
+        <div className="rounded-xl bg-slate-50 p-4 dark:bg-slate-800 border border-slate-100 dark:border-slate-700">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+            Süsteemi olek
           </p>
+          <div className="mt-2 flex items-center gap-2">
+            <span className="flex h-2 w-2 rounded-full bg-emerald-500 animate-pulse"></span>
+            <p className="text-xs font-semibold text-slate-700 dark:text-slate-300 tracking-tight">
+              Kõik töökorras
+            </p>
+          </div>
         </div>
+
+        <button
+          type="button"
+          onClick={() => {
+            localStorage.removeItem("token");
+            document.cookie = "token=; path=/; max-age=0";
+            window.location.href = "/login";
+          }}
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-slate-600 hover:bg-rose-50 hover:text-rose-600 dark:text-slate-400 dark:hover:bg-rose-900/20 dark:hover:text-rose-400 transition-all"
+        >
+          <LogoutIcon className="text-[20px]" />
+          <span className="text-sm">Logi välja</span>
+        </button>
       </div>
     </aside>
   );

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1,0 +1,25 @@
+import { apiClient } from "@/lib/apiClient";
+
+export interface LookupRecord {
+  id: string;
+  name: string;
+}
+
+function crudFor(base: string) {
+  return {
+    list: (): Promise<LookupRecord[]> =>
+      apiClient.get<LookupRecord[]>(base),
+    create: (name: string): Promise<LookupRecord> =>
+      apiClient.post<LookupRecord, { name: string }>(base, { name }),
+    update: (id: string, name: string): Promise<LookupRecord> =>
+      apiClient.put<LookupRecord, { name: string }>(`${base}/${id}`, { name }),
+    remove: (id: string): Promise<void> =>
+      apiClient.delete<void>(`${base}/${id}`),
+  };
+}
+
+export const countriesApi = crudFor("/api/countries");
+export const organizationsApi = crudFor("/api/organizations");
+export const departmentsApi = crudFor("/api/departments");
+export const rolesApi = crudFor("/api/roles");
+export const documentTypesApi = crudFor("/api/document-types");

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -7,8 +7,7 @@ export interface LookupRecord {
 
 function crudFor(base: string) {
   return {
-    list: (): Promise<LookupRecord[]> =>
-      apiClient.get<LookupRecord[]>(base),
+    list: (): Promise<LookupRecord[]> => apiClient.get<LookupRecord[]>(base),
     create: (name: string): Promise<LookupRecord> =>
       apiClient.post<LookupRecord, { name: string }>(base, { name }),
     update: (id: string, name: string): Promise<LookupRecord> =>

--- a/lib/api/adminUsers.ts
+++ b/lib/api/adminUsers.ts
@@ -1,0 +1,45 @@
+import { apiClient } from "@/lib/apiClient";
+import type { MeResponse } from "@/lib/api/auth";
+
+export type UserRole = MeResponse["role"];
+
+export interface AdminUserResponse {
+  id: string;
+  email: string;
+  role: UserRole;
+  personId: string | null;
+  person: {
+    givenName: string;
+    surname: string;
+    jobTitle: string | null;
+    socialSecurityNumber: string | null;
+    department: string | null;
+    organization: string | null;
+  } | null;
+}
+
+export interface CreateUserRequest {
+  email: string;
+  password: string;
+  role?: UserRole;
+}
+
+export interface UpdateUserRequest {
+  email?: string;
+  password?: string;
+}
+
+export const adminUsersApi = {
+  list(): Promise<AdminUserResponse[]> {
+    return apiClient.get<AdminUserResponse[]>("/api/users/admin");
+  },
+  create(body: CreateUserRequest): Promise<AdminUserResponse> {
+    return apiClient.post<AdminUserResponse, CreateUserRequest>("/api/users/admin", body);
+  },
+  update(id: string, body: UpdateUserRequest): Promise<AdminUserResponse> {
+    return apiClient.put<AdminUserResponse, UpdateUserRequest>(`/api/users/admin/${id}`, body);
+  },
+  remove(id: string): Promise<void> {
+    return apiClient.delete<void>(`/api/users/admin/${id}`);
+  },
+};

--- a/lib/api/adminUsers.ts
+++ b/lib/api/adminUsers.ts
@@ -34,10 +34,16 @@ export const adminUsersApi = {
     return apiClient.get<AdminUserResponse[]>("/api/users/admin");
   },
   create(body: CreateUserRequest): Promise<AdminUserResponse> {
-    return apiClient.post<AdminUserResponse, CreateUserRequest>("/api/users/admin", body);
+    return apiClient.post<AdminUserResponse, CreateUserRequest>(
+      "/api/users/admin",
+      body,
+    );
   },
   update(id: string, body: UpdateUserRequest): Promise<AdminUserResponse> {
-    return apiClient.put<AdminUserResponse, UpdateUserRequest>(`/api/users/admin/${id}`, body);
+    return apiClient.put<AdminUserResponse, UpdateUserRequest>(
+      `/api/users/admin/${id}`,
+      body,
+    );
   },
   remove(id: string): Promise<void> {
     return apiClient.delete<void>(`/api/users/admin/${id}`);

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -10,6 +10,34 @@ export interface AuthResponse {
   refreshToken: string;
 }
 
+export interface MeResponse {
+  id: string;
+  email: string;
+  role: "VISITOR" | "RECEPTIONIST" | "SECURITY_CHIEF" | "ADMIN";
+  personId: string | null;
+  person: {
+    givenName: string;
+    surname: string;
+    jobTitle: string | null;
+    socialSecurityNumber: string | null;
+    department: string | null;
+    organization: string | null;
+  } | null;
+}
+
 export function login(body: LoginRequest): Promise<AuthResponse> {
   return apiClient.post<AuthResponse, LoginRequest>("/api/auth/login", body);
+}
+
+export interface UpdateMeRequest {
+  email?: string;
+  password?: string;
+}
+
+export function getMe(): Promise<MeResponse> {
+  return apiClient.get<MeResponse>("/api/users/me");
+}
+
+export function updateMe(body: UpdateMeRequest): Promise<void> {
+  return apiClient.patch<void, UpdateMeRequest>("/api/users/me", body);
 }


### PR DESCRIPTION
# Description

## Summary

Adds user profile page with their details and a possibility for the user to change their email and/or password. Also additional password restrictions we didn't have before - at least one capital and one lower character and one special character. Minimum length 8 characters.
Also admin should have the privileges to edit all user data. Plus also other small lookup tables, like Role, Department, Organization, Country, DocumentTypes.

### Why

Because use should be able to view their details and change email and password.

### Related Issue

Closes #49 
Goes together with backend https://github.com/Team-Caffeine-ACS/acs-backend/pull/57

## Type of Change

- [x] New feature

## Checklist

- [x] I reviewed my own changes
- [x] I added or updated documentation where needed
- [x] I ran `npm run lint`
- [x] I ran `npx prettier --check .`
- [x] My changes were tested locally
- [x] I linked the related issue
- [x] Fixed Sonarqube issues
- [x] This PR is ready for review

## Screenshots

<img width="590" height="1036" alt="pilt" src="https://github.com/user-attachments/assets/6a54cebf-3b5a-4d44-ad9f-7a9a66356a04" />

<img width="580" height="450" alt="pilt" src="https://github.com/user-attachments/assets/b43cdcd5-cc43-4f79-a4fb-a3a70c396708" />

And input validation checks
<img width="542" height="61" alt="pilt" src="https://github.com/user-attachments/assets/c2a67015-9def-4bc8-a04e-fc70a3860eb8" />

<img width="538" height="60" alt="pilt" src="https://github.com/user-attachments/assets/3a647f28-3945-4438-9a52-887634072d67" />

Admin UI
<img width="1179" height="680" alt="pilt" src="https://github.com/user-attachments/assets/4fe7aece-a9ed-450a-a6e1-c3d3c5c48e26" />

