### PR TITLE
RefreshToken flow

### DIFF
--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -10,8 +10,9 @@ import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import ShieldIcon from "@mui/icons-material/Shield";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import { getMe, updateMe, type MeResponse } from "@/lib/api/auth";
-import { ApiError } from "@/lib/apiClient";
+import { getMe, logout, updateMe, type MeResponse } from "@/lib/api/auth";
+import { ApiError } from "@/lib/api/error";
+import { clearStoredAccessToken } from "@/lib/auth/accessToken";
 
 const ROLE_LABELS: Record<MeResponse["role"], string> = {
   VISITOR: "Külastaja",
@@ -83,9 +84,9 @@ export default function ProfilePage() {
     try {
       await updateMe(body);
       if (newEmail) {
-        // JWT subject is the old email — token is now stale, must re-login.
-        globalThis.localStorage.removeItem("token");
-        globalThis.document.cookie = "token=; path=/; max-age=0";
+        // Token is now stale after email change — clear session and re-login.
+        clearStoredAccessToken();
+        await logout().catch(() => {});
         globalThis.window.location.href = "/login";
         return;
       }

--- a/app/(protected)/visitors/page.tsx
+++ b/app/(protected)/visitors/page.tsx
@@ -11,7 +11,7 @@ import {
   Visibility,
   ChevronRight,
 } from "@mui/icons-material";
-import React, { useId, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export default function VisitorsSearchPage() {
@@ -25,7 +25,6 @@ export default function VisitorsSearchPage() {
   const updateParam = (key: string, value: string) => {
     setSearchParams((prev) => ({ ...prev, [key]: value }));
   };
-  const statusSelectId = useId();
   return (
     <div className="flex flex-col h-full animate-in fade-in duration-500">
       {/* 1. Breadcrumbs / Header sisu */}
@@ -84,12 +83,13 @@ export default function VisitorsSearchPage() {
 
             <div className="space-y-1.5 font-display">
               <label
-                htmlFor={statusSelectId}
+                htmlFor="visitors-status-filter"
                 className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1"
               >
                 Staatus
               </label>
               <select
+                id="visitors-status-filter"
                 className="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-800 border-none rounded-xl text-sm font-bold text-slate-700"
                 value={searchParams.status}
                 onChange={(e) => updateParam("status", e.target.value)}
@@ -196,18 +196,22 @@ function FilterInput({
   value,
   onChange,
 }: Readonly<FilterInputProps>) {
-  const id = useId(); // See loob unikaalse ID automaatselt
+  const inputId = `visitors-filter-${label
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/(^-|-$)/g, "")}`;
+
   return (
     <div className="space-y-1.5 font-display">
       <label
-        htmlFor={id} // <--- 1. SEO SEOS ALGAB SIIT
+        htmlFor={inputId}
         className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1 block"
       >
         {label}
       </label>
       <div className="relative">
         <input
-          id={id} // <--- 2. JA LÕPPEB SIIN
+          id={inputId}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           className="w-full pl-10 pr-4 py-2.5 bg-slate-50 dark:bg-slate-800 border-none rounded-xl text-sm font-bold placeholder:text-slate-300 focus:ring-2 focus:ring-primary/20"

--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -26,7 +26,7 @@ import {
   type PersonInRoleResponse,
 } from "@/lib/api/persons";
 import { createVisit } from "@/lib/api/visits";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 
 interface SelectedVisitor {
   personId: string;

--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useId, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import PersonIcon from "@mui/icons-material/Person";
 import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
@@ -612,13 +612,12 @@ function Field({
   readonly label: string;
   readonly children: React.ReactNode;
 }) {
-  const id = useId();
   return (
-    <div className="space-y-1.5">
-      <label htmlFor={id} className="block text-sm font-medium text-slate-700">
+    <fieldset className="space-y-1.5">
+      <legend className="block text-sm font-medium text-slate-700">
         {label}
-      </label>
-      <div id={id}>{children}</div>
-    </div>
+      </legend>
+      {children}
+    </fieldset>
   );
 }

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -11,8 +11,9 @@ import LoginIcon from "@mui/icons-material/Login";
 import SecurityIcon from "@mui/icons-material/Security";
 import LanguageIcon from "@mui/icons-material/Language";
 import DarkModeIcon from "@mui/icons-material/DarkMode";
+import { setStoredAccessToken } from "@/lib/auth/accessToken";
 import { login } from "@/lib/api/auth";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -29,9 +30,8 @@ export default function LoginPage() {
 
     try {
       const { accessToken } = await login({ email, password });
-      document.cookie = `token=${accessToken}; path=/; SameSite=Strict`;
-      localStorage.setItem("token", accessToken);
-      router.push("/");
+      setStoredAccessToken(accessToken);
+      router.replace("/");
     } catch (err) {
       setError(
         err instanceof ApiError && err.status === 401

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -100,12 +100,16 @@ export default function LoginPage() {
             <form onSubmit={handleSubmit} className="space-y-4">
               {/* Email */}
               <div className="space-y-1.5">
-                <label className="text-sm font-semibold text-slate-700 block">
+                <label
+                  htmlFor="login-email"
+                  className="text-sm font-semibold text-slate-700 block"
+                >
                   Kasutajatunnus
                 </label>
                 <div className="relative">
                   <PersonOutlineIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 !text-lg" />
                   <input
+                    id="login-email"
                     type="email"
                     required
                     value={email}
@@ -119,7 +123,10 @@ export default function LoginPage() {
               {/* Password */}
               <div className="space-y-1.5">
                 <div className="flex items-center justify-between">
-                  <label className="text-sm font-semibold text-slate-700">
+                  <label
+                    htmlFor="login-password"
+                    className="text-sm font-semibold text-slate-700"
+                  >
                     Parool
                   </label>
                   <button
@@ -132,6 +139,7 @@ export default function LoginPage() {
                 <div className="relative">
                   <LockOutlinedIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 !text-lg" />
                   <input
+                    id="login-password"
                     type={showPassword ? "text" : "password"}
                     required
                     value={password}

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -52,18 +52,18 @@ export default function LoginPage() {
           Pääsla infosüsteem
         </div>
         <nav className="flex items-center gap-6">
-          <a
-            href="#"
+          <button
+            type="button"
             className="text-sm font-semibold text-slate-600 hover:text-slate-900"
           >
             Abi
-          </a>
-          <a
-            href="#"
+          </button>
+          <button
+            type="button"
             className="text-sm font-semibold text-slate-600 hover:text-slate-900"
           >
             Kontakt
-          </a>
+          </button>
           <button
             aria-label="Vaheta teema"
             className="p-2 rounded-full hover:bg-slate-200 text-slate-500 transition-colors"
@@ -122,12 +122,12 @@ export default function LoginPage() {
                   <label className="text-sm font-semibold text-slate-700">
                     Parool
                   </label>
-                  <a
-                    href="#"
+                  <button
+                    type="button"
                     className="text-xs font-semibold text-blue-600 hover:underline"
                   >
                     Unustasid parooli?
-                  </a>
+                  </button>
                 </div>
                 <div className="relative">
                   <LockOutlinedIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 !text-lg" />

--- a/app/api/session/login/route.ts
+++ b/app/api/session/login/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import type { LoginRequest } from "@/lib/api/auth";
+import {
+  type BackendAuthResponse,
+  postAuthToBackend,
+  readJsonResponse,
+  setRefreshTokenCookie,
+} from "@/lib/server/auth";
+
+export async function POST(request: Request) {
+  try {
+    const credentials = (await request.json()) as LoginRequest;
+    const backendResponse = await postAuthToBackend(
+      "/api/auth/login",
+      credentials,
+    );
+    const payload =
+      await readJsonResponse<BackendAuthResponse>(backendResponse);
+
+    if (!backendResponse.ok) {
+      return NextResponse.json(
+        payload ?? { message: "Sisselogimine ebaõnnestus." },
+        { status: backendResponse.status },
+      );
+    }
+
+    if (!payload?.accessToken || !payload.refreshToken) {
+      return NextResponse.json(
+        { message: "Autentimisvastus oli vigane." },
+        { status: 502 },
+      );
+    }
+
+    await setRefreshTokenCookie(payload.refreshToken);
+
+    return NextResponse.json(
+      { accessToken: payload.accessToken },
+      { status: backendResponse.status },
+    );
+  } catch {
+    return NextResponse.json(
+      { message: "Sisselogimine ebaõnnestus." },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/session/logout/route.ts
+++ b/app/api/session/logout/route.ts
@@ -1,0 +1,6 @@
+import { clearRefreshTokenCookie } from "@/lib/server/auth";
+
+export async function POST() {
+  await clearRefreshTokenCookie();
+  return new Response(null, { status: 204 });
+}

--- a/app/api/session/refresh/route.ts
+++ b/app/api/session/refresh/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import {
+  type BackendAuthResponse,
+  clearRefreshTokenCookie,
+  getRefreshTokenCookie,
+  postAuthToBackend,
+  readJsonResponse,
+  setRefreshTokenCookie,
+} from "@/lib/server/auth";
+
+export async function POST() {
+  try {
+    const refreshToken = await getRefreshTokenCookie();
+
+    if (!refreshToken) {
+      await clearRefreshTokenCookie();
+      return NextResponse.json(
+        { message: "Seanss on aegunud. Palun logige uuesti sisse." },
+        { status: 401 },
+      );
+    }
+
+    const backendResponse = await postAuthToBackend("/api/auth/refresh", {
+      refreshToken,
+    });
+    const payload =
+      await readJsonResponse<BackendAuthResponse>(backendResponse);
+
+    if (!backendResponse.ok) {
+      await clearRefreshTokenCookie();
+      return NextResponse.json(
+        payload ?? { message: "Seanss on aegunud. Palun logige uuesti sisse." },
+        { status: backendResponse.status },
+      );
+    }
+
+    if (!payload?.accessToken || !payload.refreshToken) {
+      await clearRefreshTokenCookie();
+      return NextResponse.json(
+        { message: "Autentimisvastus oli vigane." },
+        { status: 502 },
+      );
+    }
+
+    await setRefreshTokenCookie(payload.refreshToken);
+
+    return NextResponse.json({ accessToken: payload.accessToken });
+  } catch {
+    await clearRefreshTokenCookie();
+    return NextResponse.json(
+      { message: "Seansi värskendamine ebaõnnestus." },
+      { status: 502 },
+    );
+  }
+}

--- a/components/admin/LookupManager.tsx
+++ b/components/admin/LookupManager.tsx
@@ -7,7 +7,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 import { type LookupRecord } from "@/lib/api/admin";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 
 interface Api {
   list(): Promise<LookupRecord[]>;

--- a/components/admin/UserManager.tsx
+++ b/components/admin/UserManager.tsx
@@ -12,7 +12,7 @@ import {
   type AdminUserResponse,
   type UserRole,
 } from "@/lib/api/adminUsers";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 
 const ROLES: UserRole[] = [
   "VISITOR",

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import { ApiError, extractErrorMessage, parseErrorData } from "@/lib/api/error";
+import { apiClient } from "@/lib/apiClient";
 
 export interface LoginRequest {
   email: string;
@@ -57,6 +58,21 @@ export function logout(): Promise<void> {
   return requestSession<void>("/api/session/logout", {
     method: "POST",
   });
+}
+
+export interface MeResponse {
+  id: string;
+  email: string;
+  role: "VISITOR" | "RECEPTIONIST" | "SECURITY_CHIEF" | "ADMIN";
+  personId: string | null;
+  person: {
+    givenName: string;
+    surname: string;
+    jobTitle: string | null;
+    socialSecurityNumber: string | null;
+    department: string | null;
+    organization: string | null;
+  } | null;
 }
 
 export interface UpdateMeRequest {

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -30,7 +30,11 @@ async function requestSession<TResponse>(
   const data = await parseErrorData(response);
 
   if (!response.ok) {
-    throw new ApiError(response.status, extractErrorMessage(data, response), data);
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(data, response),
+      data,
+    );
   }
 
   return data as TResponse;

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,15 +1,56 @@
-import { apiClient } from "@/lib/apiClient";
+import { ApiError, extractErrorMessage, parseErrorData } from "@/lib/api/error";
 
 export interface LoginRequest {
   email: string;
   password: string;
 }
 
-export interface AuthResponse {
+export interface AccessTokenResponse {
   accessToken: string;
-  refreshToken: string;
 }
 
-export function login(body: LoginRequest): Promise<AuthResponse> {
-  return apiClient.post<AuthResponse, LoginRequest>("/api/auth/login", body);
+async function requestSession<TResponse>(
+  path: string,
+  init: RequestInit = {},
+): Promise<TResponse> {
+  const response = await fetch(path, {
+    ...init,
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+
+  if (response.status === 204) {
+    return undefined as TResponse;
+  }
+
+  const data = await parseErrorData(response);
+
+  if (!response.ok) {
+    throw new ApiError(response.status, extractErrorMessage(data, response), data);
+  }
+
+  return data as TResponse;
+}
+
+export function login(body: LoginRequest): Promise<AccessTokenResponse> {
+  return requestSession<AccessTokenResponse>("/api/session/login", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function refreshAccessToken(): Promise<AccessTokenResponse> {
+  return requestSession<AccessTokenResponse>("/api/session/refresh", {
+    method: "POST",
+  });
+}
+
+export function logout(): Promise<void> {
+  return requestSession<void>("/api/session/logout", {
+    method: "POST",
+  });
 }

--- a/lib/api/error.ts
+++ b/lib/api/error.ts
@@ -1,0 +1,34 @@
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export async function parseErrorData(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractErrorMessage(
+  errorData: unknown,
+  response: Response,
+): string {
+  if (
+    typeof errorData === "object" &&
+    errorData !== null &&
+    "message" in errorData &&
+    typeof (errorData as Record<string, unknown>).message === "string"
+  ) {
+    return (errorData as Record<string, string>).message;
+  }
+
+  return `HTTP ${response.status}: ${response.statusText}`;
+}

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -26,6 +26,23 @@ function getAuthHeaders(
   return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
 }
 
+function serializeRequestBody(body: unknown): string | undefined {
+  if (body === undefined) {
+    return undefined;
+  }
+
+  return JSON.stringify(body);
+}
+
+function logRequest(method: HttpMethod, path: string, body: unknown): void {
+  if (LOG) {
+    console.log(
+      `[apiClient] --> ${method} ${BASE_URL}${path}`,
+      body === undefined ? "" : body,
+    );
+  }
+}
+
 async function parseResponse<TResponse>(
   method: HttpMethod,
   path: string,
@@ -92,21 +109,14 @@ async function throwForResponse(
   throw new ApiError(response.status, message, errorData);
 }
 
-async function request<TResponse>(
+function createRequestExecutor(
   method: HttpMethod,
   path: string,
-  options: RequestOptions & { body?: unknown } = {},
-): Promise<TResponse> {
-  const { headers, signal, body } = options;
-  const serializedBody = body !== undefined ? JSON.stringify(body) : undefined;
-
-  if (LOG)
-    console.log(
-      `[apiClient] --> ${method} ${BASE_URL}${path}`,
-      body === undefined ? "" : body,
-    );
-
-  const executeRequest = (accessToken?: string | null) =>
+  headers: Record<string, string> | undefined,
+  signal: AbortSignal | undefined,
+  serializedBody: string | undefined,
+) {
+  return (accessToken?: string | null) =>
     fetch(`${BASE_URL}${path}`, {
       method,
       headers: {
@@ -118,6 +128,54 @@ async function request<TResponse>(
       body: serializedBody,
       signal,
     });
+}
+
+function canRefreshUnauthorizedResponse(response: Response): boolean {
+  return response.status === 401 && globalThis.window !== undefined;
+}
+
+async function retryRequestAfterRefresh<TResponse>(
+  method: HttpMethod,
+  path: string,
+  executeRequest: (accessToken?: string | null) => Promise<Response>,
+): Promise<TResponse> {
+  try {
+    const freshAccessToken = await refreshStoredAccessToken();
+    const retryResponse = await executeRequest(freshAccessToken);
+
+    if (retryResponse.ok) {
+      return parseResponse<TResponse>(method, path, retryResponse);
+    }
+
+    if (retryResponse.status === 401) {
+      return handleUnauthorized();
+    }
+
+    return throwForResponse(method, path, retryResponse);
+  } catch (error) {
+    if (error instanceof ApiError && error.status !== 401) {
+      throw error;
+    }
+
+    return handleUnauthorized();
+  }
+}
+
+async function request<TResponse>(
+  method: HttpMethod,
+  path: string,
+  options: RequestOptions & { body?: unknown } = {},
+): Promise<TResponse> {
+  const { headers, signal, body } = options;
+  const serializedBody = serializeRequestBody(body);
+  logRequest(method, path, body);
+  const executeRequest = createRequestExecutor(
+    method,
+    path,
+    headers,
+    signal,
+    serializedBody,
+  );
 
   const response = await executeRequest();
 
@@ -125,27 +183,8 @@ async function request<TResponse>(
     return parseResponse<TResponse>(method, path, response);
   }
 
-  if (response.status === 401 && globalThis.window !== undefined) {
-    try {
-      const freshAccessToken = await refreshStoredAccessToken();
-      const retryResponse = await executeRequest(freshAccessToken);
-
-      if (retryResponse.ok) {
-        return parseResponse<TResponse>(method, path, retryResponse);
-      }
-
-      if (retryResponse.status === 401) {
-        return handleUnauthorized();
-      }
-
-      return throwForResponse(method, path, retryResponse);
-    } catch (error) {
-      if (error instanceof ApiError && error.status !== 401) {
-        throw error;
-      }
-
-      return handleUnauthorized();
-    }
+  if (canRefreshUnauthorizedResponse(response)) {
+    return retryRequestAfterRefresh<TResponse>(method, path, executeRequest);
   }
 
   return throwForResponse(method, path, response);

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -1,16 +1,10 @@
+import { clearStoredAccessToken, getStoredAccessToken, setStoredAccessToken } from "@/lib/auth/accessToken";
+import { LOGIN_PATH } from "@/lib/auth/constants";
+import { logout, refreshAccessToken } from "@/lib/api/auth";
+import { ApiError, extractErrorMessage, parseErrorData } from "@/lib/api/error";
+
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 const LOG = process.env.NEXT_PUBLIC_DEBUG === "true";
-
-export class ApiError extends Error {
-  constructor(
-    public readonly status: number,
-    message: string,
-    public readonly data?: unknown,
-  ) {
-    super(message);
-    this.name = "ApiError";
-  }
-}
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
@@ -24,42 +18,63 @@ interface MutationOptions<TBody> extends RequestOptions {
   body?: TBody;
 }
 
-function getAuthHeaders(): Record<string, string> {
-  if (globalThis.window === undefined) return {};
-  const token =
-    localStorage.getItem("token") ??
-    document.cookie
-      .split("; ")
-      .find((c) => c.startsWith("token="))
-      ?.slice("token=".length);
-  return token ? { Authorization: `Bearer ${token}` } : {};
+let refreshRequest: Promise<string> | null = null;
+
+function getAuthHeaders(
+  accessToken = getStoredAccessToken(),
+): Record<string, string> {
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
 }
 
-async function parseErrorData(response: Response): Promise<unknown> {
+async function parseResponse<TResponse>(
+  method: HttpMethod,
+  path: string,
+  response: Response,
+): Promise<TResponse> {
+  if (response.status === 204) {
+    if (LOG) console.log(`[apiClient] <-- ${method} ${path} 204 No Content`);
+    return undefined as TResponse;
+  }
+
+  const data = (await response.json()) as TResponse;
+  if (LOG)
+    console.log(`[apiClient] <-- ${method} ${path} ${response.status}`, data);
+  return data;
+}
+
+async function clearSession(): Promise<void> {
+  clearStoredAccessToken();
+
+  if (globalThis.window === undefined) return;
+
   try {
-    return await response.json();
+    await logout();
   } catch {
-    return undefined;
+    // Best effort cleanup of the HttpOnly refresh cookie.
   }
 }
 
-function extractErrorMessage(errorData: unknown, response: Response): string {
-  if (
-    typeof errorData === "object" &&
-    errorData !== null &&
-    "message" in errorData &&
-    typeof (errorData as Record<string, unknown>).message === "string"
-  ) {
-    return (errorData as Record<string, string>).message;
-  }
-  return `HTTP ${response.status}: ${response.statusText}`;
-}
+async function handleUnauthorized(): Promise<never> {
+  await clearSession();
 
-function handleUnauthorized(): never {
-  globalThis.localStorage.removeItem("token");
-  globalThis.document.cookie = "token=; path=/; max-age=0";
-  globalThis.window.location.href = "/login";
+  if (globalThis.window !== undefined) {
+    globalThis.window.location.href = LOGIN_PATH;
+  }
+
   throw new ApiError(401, "Seanss on aegunud. Palun logige uuesti sisse.");
+}
+
+async function refreshStoredAccessToken(): Promise<string> {
+  refreshRequest ??= refreshAccessToken()
+      .then(({ accessToken }) => {
+        setStoredAccessToken(accessToken);
+        return accessToken;
+      })
+      .finally(() => {
+        refreshRequest = null;
+      });
+
+  return refreshRequest;
 }
 
 async function throwForResponse(
@@ -67,12 +82,6 @@ async function throwForResponse(
   path: string,
   response: Response,
 ): Promise<never> {
-  if (response.status === 401) {
-    if (globalThis.window === undefined) {
-      throw new ApiError(401, "Seanss on aegunud. Palun logige uuesti sisse.");
-    }
-    handleUnauthorized();
-  }
   const errorData = await parseErrorData(response);
   const message = extractErrorMessage(errorData, response);
   if (LOG)
@@ -89,6 +98,7 @@ async function request<TResponse>(
   options: RequestOptions & { body?: unknown } = {},
 ): Promise<TResponse> {
   const { headers, signal, body } = options;
+  const serializedBody = body !== undefined ? JSON.stringify(body) : undefined;
 
   if (LOG)
     console.log(
@@ -96,31 +106,49 @@ async function request<TResponse>(
       body === undefined ? "" : body,
     );
 
-  const response = await fetch(`${BASE_URL}${path}`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      ...getAuthHeaders(),
-      ...headers,
-    },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-    signal,
-  });
+  const executeRequest = (accessToken?: string | null) =>
+    fetch(`${BASE_URL}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...getAuthHeaders(accessToken),
+        ...headers,
+      },
+      body: serializedBody,
+      signal,
+    });
 
-  if (!response.ok) {
-    await throwForResponse(method, path, response);
+  const response = await executeRequest();
+
+  if (response.ok) {
+    return parseResponse<TResponse>(method, path, response);
   }
 
-  if (response.status === 204) {
-    if (LOG) console.log(`[apiClient] <-- ${method} ${path} 204 No Content`);
-    return undefined as TResponse;
+  if (response.status === 401 && globalThis.window !== undefined) {
+    try {
+      const freshAccessToken = await refreshStoredAccessToken();
+      const retryResponse = await executeRequest(freshAccessToken);
+
+      if (retryResponse.ok) {
+        return parseResponse<TResponse>(method, path, retryResponse);
+      }
+
+      if (retryResponse.status === 401) {
+        return handleUnauthorized();
+      }
+
+      return throwForResponse(method, path, retryResponse);
+    } catch (error) {
+      if (error instanceof ApiError && error.status !== 401) {
+        throw error;
+      }
+
+      return handleUnauthorized();
+    }
   }
 
-  const data = await response.json();
-  if (LOG)
-    console.log(`[apiClient] <-- ${method} ${path} ${response.status}`, data);
-  return data as TResponse;
+  return throwForResponse(method, path, response);
 }
 
 export const apiClient = {

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -1,4 +1,8 @@
-import { clearStoredAccessToken, getStoredAccessToken, setStoredAccessToken } from "@/lib/auth/accessToken";
+import {
+  clearStoredAccessToken,
+  getStoredAccessToken,
+  setStoredAccessToken,
+} from "@/lib/auth/accessToken";
 import { LOGIN_PATH } from "@/lib/auth/constants";
 import { logout, refreshAccessToken } from "@/lib/api/auth";
 import { ApiError, extractErrorMessage, parseErrorData } from "@/lib/api/error";
@@ -83,13 +87,13 @@ async function handleUnauthorized(): Promise<never> {
 
 async function refreshStoredAccessToken(): Promise<string> {
   refreshRequest ??= refreshAccessToken()
-      .then(({ accessToken }) => {
-        setStoredAccessToken(accessToken);
-        return accessToken;
-      })
-      .finally(() => {
-        refreshRequest = null;
-      });
+    .then(({ accessToken }) => {
+      setStoredAccessToken(accessToken);
+      return accessToken;
+    })
+    .finally(() => {
+      refreshRequest = null;
+    });
 
   return refreshRequest;
 }

--- a/lib/auth/accessToken.ts
+++ b/lib/auth/accessToken.ts
@@ -1,0 +1,35 @@
+import { ACCESS_TOKEN_STORAGE_KEY } from "@/lib/auth/constants";
+
+let inMemoryAccessToken: string | null | undefined;
+
+function canUseBrowserStorage(): boolean {
+  return globalThis.window !== undefined;
+}
+
+export function getStoredAccessToken(): string | null {
+  if (!canUseBrowserStorage()) return null;
+
+  if (inMemoryAccessToken !== undefined) {
+    return inMemoryAccessToken;
+  }
+
+  const token = globalThis.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+  inMemoryAccessToken = token;
+  return token;
+}
+
+export function setStoredAccessToken(token: string): void {
+  if (!canUseBrowserStorage()) return;
+
+  inMemoryAccessToken = token;
+  globalThis.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, token);
+  globalThis.document.cookie = "token=; path=/; max-age=0; SameSite=Strict";
+}
+
+export function clearStoredAccessToken(): void {
+  if (!canUseBrowserStorage()) return;
+
+  inMemoryAccessToken = null;
+  globalThis.localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  globalThis.document.cookie = "token=; path=/; max-age=0; SameSite=Strict";
+}

--- a/lib/auth/constants.ts
+++ b/lib/auth/constants.ts
@@ -1,0 +1,3 @@
+export const ACCESS_TOKEN_STORAGE_KEY = "token";
+export const REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+export const LOGIN_PATH = "/login";

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { REFRESH_TOKEN_COOKIE_NAME } from "@/lib/auth/constants";
+
+export interface BackendAuthResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface JwtPayload {
+  exp?: number;
+}
+
+function getApiBaseUrl(): string {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL is not configured.");
+  }
+
+  return baseUrl.replace(/\/$/, "");
+}
+
+export async function postAuthToBackend(
+  path: string,
+  body: unknown,
+): Promise<Response> {
+  return fetch(`${getApiBaseUrl()}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+}
+
+export async function readJsonResponse<T>(response: Response): Promise<T | null> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function getRefreshTokenCookie(): Promise<string | null> {
+  const cookieStore = await cookies();
+  return cookieStore.get(REFRESH_TOKEN_COOKIE_NAME)?.value ?? null;
+}
+
+function decodeJwtPayload(token: string): JwtPayload {
+  const [, payload] = token.split(".");
+
+  if (!payload) {
+    throw new Error("Refresh token payload is missing.");
+  }
+
+  const base64 = payload.replaceAll('-', "+").replaceAll('_', "/");
+  const paddedBase64 = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "=",
+  );
+
+  return JSON.parse(Buffer.from(paddedBase64, "base64").toString("utf8")) as JwtPayload;
+}
+
+function getRefreshTokenMaxAgeSeconds(refreshToken: string): number {
+  const payload = decodeJwtPayload(refreshToken);
+
+  if (
+    typeof payload.exp !== "number" ||
+    !Number.isFinite(payload.exp) ||
+    payload.exp <= 0
+  ) {
+    throw new Error("Refresh token exp claim is missing or invalid.");
+  }
+
+  return Math.max(0, Math.floor(payload.exp - Date.now() / 1000));
+}
+
+export async function setRefreshTokenCookie(refreshToken: string): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(REFRESH_TOKEN_COOKIE_NAME, refreshToken, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: getRefreshTokenMaxAgeSeconds(refreshToken),
+  });
+}
+
+export async function clearRefreshTokenCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(REFRESH_TOKEN_COOKIE_NAME, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+}

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -37,7 +37,9 @@ export async function postAuthToBackend(
   });
 }
 
-export async function readJsonResponse<T>(response: Response): Promise<T | null> {
+export async function readJsonResponse<T>(
+  response: Response,
+): Promise<T | null> {
   try {
     return (await response.json()) as T;
   } catch {
@@ -57,13 +59,15 @@ function decodeJwtPayload(token: string): JwtPayload {
     throw new Error("Refresh token payload is missing.");
   }
 
-  const base64 = payload.replaceAll('-', "+").replaceAll('_', "/");
+  const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
   const paddedBase64 = base64.padEnd(
     base64.length + ((4 - (base64.length % 4)) % 4),
     "=",
   );
 
-  return JSON.parse(Buffer.from(paddedBase64, "base64").toString("utf8")) as JwtPayload;
+  return JSON.parse(
+    Buffer.from(paddedBase64, "base64").toString("utf8"),
+  ) as JwtPayload;
 }
 
 function getRefreshTokenMaxAgeSeconds(refreshToken: string): number {
@@ -80,7 +84,9 @@ function getRefreshTokenMaxAgeSeconds(refreshToken: string): number {
   return Math.max(0, Math.floor(payload.exp - Date.now() / 1000));
 }
 
-export async function setRefreshTokenCookie(refreshToken: string): Promise<void> {
+export async function setRefreshTokenCookie(
+  refreshToken: string,
+): Promise<void> {
   const cookieStore = await cookies();
   cookieStore.set(REFRESH_TOKEN_COOKIE_NAME, refreshToken, {
     httpOnly: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^7.3.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "hono": ">=4.12.14",
         "lucide-react": "^1.6.0",
         "next": "^16.2.3",
         "radix-ui": "^1.4.3",
@@ -7509,9 +7510,10 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint --max-warnings 0"
   },
   "dependencies": {
+    "hono": ">=4.12.14",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.9",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,15 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { LOGIN_PATH, REFRESH_TOKEN_COOKIE_NAME } from "@/lib/auth/constants";
 
 export function proxy(request: NextRequest) {
-  const token = request.cookies.get("token")?.value;
+  const token = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME)?.value;
   const { pathname } = request.nextUrl;
 
-  if (!token && pathname !== "/login") {
-    return NextResponse.redirect(new URL("/login", request.url));
-  }
-
-  if (token && pathname === "/login") {
-    return NextResponse.redirect(new URL("/", request.url));
+  if (!token && pathname !== LOGIN_PATH) {
+    return NextResponse.redirect(new URL(LOGIN_PATH, request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
# Description

## Summary

Implements refresh token flow for frontend authentication.

This PR moves refresh token handling behind Next.js session route handlers, stores the refresh token in an HttpOnly cookie, and adds automatic access token refresh when API requests return 401.

### Why

Previously the frontend only stored and reused the access token. When it expired, users had to log in again manually.

This change improves session continuity and aligns the frontend with the backend auth contract:

- login returns accessToken + refreshToken
- refresh is done through POST /api/auth/refresh
- refresh token expiry is derived from the JWT exp claim
- protected requests retry automatically after a successful refresh

### Related Issue

Closes the refresh-token flow issue for auth/session handling.

## Type of Change

- [X] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Documentation update
- [ ] Styling / UI update
- [ ] Other

## Checklist

- [x] I reviewed my own changes
- [ ] I added or updated documentation where needed
- [X] I ran `npm run lint`
- [ ] I ran `npx prettier --check .`
- [X] My changes were tested locally
- [ ] I linked the related issue
- [X] This PR is ready for review

## Additional Notes

Key implementation details:

- Added Next.js session proxy routes for login, refresh, and logout.
- Refresh token is no longer exposed to client-side JS.
- Refresh token is stored in an HttpOnly, SameSite=Strict cookie.
- Cookie lifetime is calculated from the refresh JWT exp claim, not hardcoded.
- API client now retries once after a 401 by requesting a new access token.
- If refresh fails, the frontend clears session state and redirects to /login.

Reviewer note:

Backend currently returns the same refresh token on refresh, so the frontend preserves cookie lifetime based on that token’s remaining JWT validity rather than resetting it to a full new duration.
