### PR TITLE
Fix: unify ApiError imports under api/error

### DIFF
--- a/app/(protected)/keys/[id]/page.tsx
+++ b/app/(protected)/keys/[id]/page.tsx
@@ -12,7 +12,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import EventAvailableIcon from "@mui/icons-material/EventAvailable";
 import AssignmentReturnIcon from "@mui/icons-material/AssignmentReturn";
 import { Button } from "@/components/ui/button";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 import {
   getKeycard,
   getKeycardStatusLabel,

--- a/app/(protected)/keys/[id]/return/page.tsx
+++ b/app/(protected)/keys/[id]/return/page.tsx
@@ -14,7 +14,7 @@ import {
   getAccessPoints,
   type AccessPointResponse,
 } from "@/lib/api/accessPoints";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 import {
   getKeycard,
   getKeycardStatusLabel,

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -14,7 +14,7 @@ import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import InfoIcon from "@mui/icons-material/Info";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 import {
   getKeycard,
   getKeycards,

--- a/app/(protected)/visits/[visitId]/visit-detail-page.tsx
+++ b/app/(protected)/visits/[visitId]/visit-detail-page.tsx
@@ -24,7 +24,7 @@ import MeetingRoomOutlinedIcon from "@mui/icons-material/MeetingRoomOutlined";
 import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
 import PrintOutlinedIcon from "@mui/icons-material/PrintOutlined";
 import { Button } from "@/components/ui/button";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 import { getKeycardById, type KeycardResponse } from "@/lib/api/keycards";
 import {
   deriveVisitStatus,

--- a/app/(protected)/visits/page.tsx
+++ b/app/(protected)/visits/page.tsx
@@ -9,7 +9,7 @@ import FilterListIcon from "@mui/icons-material/FilterList";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import { Button } from "@/components/ui/button";
-import { ApiError } from "@/lib/apiClient";
+import { ApiError } from "@/lib/api/error";
 import {
   deriveVisitStatus,
   getVisits,


### PR DESCRIPTION
# Description

## Summary

Standardizes `ApiError` imports across the codebase by making `@/lib/api/error` the single canonical module for the error type.

This PR removes the inconsistent `ApiError` re-export from `@/lib/apiClient` and updates affected pages to import `ApiError` directly from `@/lib/api/error`.

### Why

The codebase had a module surface mismatch:

- `ApiError` was defined in `@/lib/api/error`
- some consumers imported it from `@/lib/apiClient`
- `@/lib/apiClient` did not originally export `ApiError`

That caused TypeScript errors such as:

`Module '"@/lib/apiClient"' declares 'ApiError' locally, but it is not exported.`

This change makes ownership explicit and prevents the API client module from leaking unrelated error exports.

### Related Issue

Closes #<issue-number>

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Styling / UI update
- [ ] Other

## Checklist

- [x] I reviewed my own changes
- [ ] I added or updated documentation where needed
- [ ] I ran `npm run lint`
- [ ] I ran `npx prettier --check .`
- [x] My changes were tested locally
- [ ] I linked the related issue
- [x] This PR is ready for review

## Screenshots

N/A

## Additional Notes

Local verification performed:
- `npx tsc --noEmit`

Files updated:
- `lib/apiClient.ts`
- `app/(protected)/keys/page.tsx`
- `app/(protected)/keys/[id]/page.tsx`
- `app/(protected)/keys/[id]/return/page.tsx`
- `app/(protected)/visits/page.tsx`
- `app/(protected)/visits/[visitId]/visit-detail-page.tsx`
