### PR TITLE
fix: show organization and social security nr at new visit

### DIFF
--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -59,6 +59,8 @@ export default function NewVisitPage() {
   const [givenName, setGivenName] = useState("");
   const [surname, setSurname] = useState("");
   const [email, setEmail] = useState("");
+  const [organization, setOrganization] = useState("");
+  const [identityCode, setIdentityCode] = useState("");
   const [documentTypeId, setDocumentTypeId] = useState("");
   const [documentNumber, setDocumentNumber] = useState("");
 
@@ -160,6 +162,8 @@ export default function NewVisitPage() {
           givenName: givenName.trim(),
           surname: surname.trim(),
           email: email.trim(),
+          organization: organization.trim() || undefined,
+          socialSecurityNumber: identityCode.trim() || undefined,
           documentTypeId: documentTypeId || undefined,
           documentNumber: documentNumber.trim() || undefined,
         });
@@ -375,6 +379,28 @@ export default function NewVisitPage() {
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="nt. jaan@example.com"
                     maxLength={255}
+                    className={inputCls}
+                  />
+                </Field>
+                <Field label="Organisatsioon">
+                  <input
+                    type="text"
+                    value={organization}
+                    onChange={(e) => setOrganization(e.target.value)}
+                    placeholder="Sisesta organisatsioon"
+                    maxLength={255}
+                    className={inputCls}
+                  />
+                </Field>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <Field label="Isikukood">
+                  <input
+                    type="text"
+                    value={identityCode}
+                    onChange={(e) => setIdentityCode(e.target.value)}
+                    placeholder="Sisesta isikukood"
+                    maxLength={128}
                     className={inputCls}
                   />
                 </Field>

--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -372,13 +372,13 @@ export default function NewVisitPage() {
                 </Field>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <Field label="E-posti aadress *">
+                <Field label="Isikukood">
                   <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="nt. jaan@example.com"
-                    maxLength={255}
+                    type="text"
+                    value={identityCode}
+                    onChange={(e) => setIdentityCode(e.target.value)}
+                    placeholder="Sisesta isikukood"
+                    maxLength={128}
                     className={inputCls}
                   />
                 </Field>
@@ -394,13 +394,13 @@ export default function NewVisitPage() {
                 </Field>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <Field label="Isikukood">
+                <Field label="E-posti aadress *">
                   <input
-                    type="text"
-                    value={identityCode}
-                    onChange={(e) => setIdentityCode(e.target.value)}
-                    placeholder="Sisesta isikukood"
-                    maxLength={128}
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="nt. jaan@example.com"
+                    maxLength={255}
                     className={inputCls}
                   />
                 </Field>
@@ -638,10 +638,14 @@ function Field({
   readonly label: string;
   readonly children: React.ReactNode;
 }) {
+  const isRequired = label.endsWith(" *");
+  const visibleLabel = isRequired ? label.slice(0, -2) : label;
+
   return (
     <fieldset className="space-y-1.5">
       <legend className="block text-sm font-medium text-slate-700">
-        {label}
+        {visibleLabel}
+        {isRequired && <span className="text-rose-600"> *</span>}
       </legend>
       {children}
     </fieldset>

--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -153,8 +153,15 @@ export default function NewVisitPage() {
       let personId: string;
 
       if (showCreateForm && !selectedVisitor) {
-        if (!givenName.trim() || !surname.trim() || !email.trim()) {
-          setSubmitError("Täida eesnimi, perekonnanimi ja e-posti aadress.");
+        if (
+          !givenName.trim() ||
+          !surname.trim() ||
+          !identityCode.trim() ||
+          !email.trim()
+        ) {
+          setSubmitError(
+            "Täida eesnimi, perekonnanimi, isikukood ja e-posti aadress.",
+          );
           setIsSubmitting(false);
           return;
         }
@@ -372,13 +379,14 @@ export default function NewVisitPage() {
                 </Field>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <Field label="Isikukood">
+                <Field label="Isikukood *">
                   <input
                     type="text"
                     value={identityCode}
                     onChange={(e) => setIdentityCode(e.target.value)}
                     placeholder="Sisesta isikukood"
                     maxLength={128}
+                    required
                     className={inputCls}
                   />
                 </Field>

--- a/app/(protected)/visits/new/page.tsx
+++ b/app/(protected)/visits/new/page.tsx
@@ -220,7 +220,7 @@ export default function NewVisitPage() {
           title="Külalise andmed"
         >
           {/* Visitor search */}
-          {!selectedVisitor && (
+          {!selectedVisitor && !showCreateForm && (
             <div className="space-y-3">
               <div className="flex gap-2">
                 <input

--- a/lib/api/persons.ts
+++ b/lib/api/persons.ts
@@ -20,6 +20,8 @@ export interface CreatePersonRequest {
   givenName: string;
   surname: string;
   email: string;
+  organization?: string;
+  socialSecurityNumber?: string;
   documentTypeId?: string;
   documentNumber?: string;
 }


### PR DESCRIPTION
## Summary

Added optional fields to the new visitor creation form:

- Organization
- Identity code

The values are trimmed before submission, and empty values are omitted from the request. `CreatePersonRequest` was extended with `organization` and `socialSecurityNumber`.

## Validation

- `npm run lint` passed.
- `git diff --check` passed.
- `npx tsc --noEmit` is currently blocked by an existing missing `react-leaflet` module/type issue in `components/AccessPointMap.tsx`.

# Screenshots

<img width="625" height="158" alt="image" src="https://github.com/user-attachments/assets/d0cacc52-0d11-4239-9100-48eab364d099" />

<img width="619" height="339" alt="image" src="https://github.com/user-attachments/assets/6c9d22e9-f882-4b98-b0cd-bf4f9002f06a" />

## Note
- when creating new visitor - hided the search bar, "<-- tagasi otsingusse" link remained
- Made Identity code (Isikukood) as mandatory. No anonymous person can get to the building.
- The backend must accept and persist these new fields in `/api/persons`.
