### PR TITLE
Bug/89 mugulane bug visit detail page imports editvisit but libapivisits does not export it

### DIFF
--- a/app/(protected)/page.tsx
+++ b/app/(protected)/page.tsx
@@ -5,7 +5,7 @@ import {
   getDashboardSummary,
   DashboardSummaryResponse,
 } from "@/lib/api/dashboard";
-import { VisitListItemResponse, getRecentVisits } from "@/lib/api/visits";
+import { VisitListItemResponse, getLatestVisits } from "@/lib/api/visits";
 import { AccessPointResponse, getAccessPoints } from "@/lib/api/accessPoints";
 import "leaflet/dist/leaflet.css";
 
@@ -55,7 +55,7 @@ export default function DashboardPage() {
         // Teeme mõlemad päringud korraga
         const [summaryData, visitsData, apData] = await Promise.all([
           getDashboardSummary(),
-          getRecentVisits({ page: 0, size: 5 }), // Küsime näiteks 5 viimast
+          getLatestVisits({ page: 0, size: 5 }), // Küsime näiteks 5 viimast
           getAccessPoints(),
         ]);
 

--- a/lib/api/visits.ts
+++ b/lib/api/visits.ts
@@ -146,6 +146,24 @@ export type VisitStatusKey =
   | "cancelled"
   | "unknown";
 
+const VISIT_STATUS_ALL = "all";
+const DEFAULT_VISITS_PAGE = 0;
+const DEFAULT_VISITS_PAGE_SIZE = 50;
+const DEFAULT_RECENT_VISITS_PAGE_SIZE = 20;
+const DEFAULT_RECENT_VISITS_SORT = "entryTime,desc";
+
+type VisitListResponsePayload = Record<string, unknown> | unknown[];
+
+interface VisitListQueryParams {
+  search?: string;
+  status?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -305,7 +323,7 @@ function normalizeVisitPageMetadata(raw: unknown): VisitPageMetadata | null {
   };
 }
 
-function normalizeVisitListResponse(raw: unknown): VisitListPage {
+function normalizeVisitCollectionResponse(raw: unknown): VisitListPage {
   if (Array.isArray(raw)) {
     return {
       content: raw.filter(isRecord).map(normalizeVisitListItem),
@@ -329,7 +347,9 @@ function normalizeVisitListResponse(raw: unknown): VisitListPage {
   };
 }
 
-function normalizeVisitListPage(raw: unknown): Page<VisitListItemResponse> {
+function normalizePagedVisitCollectionResponse(
+  raw: unknown,
+): Page<VisitListItemResponse> {
   // Kontrollime, et 'raw' on üldse objekt, et vältida runtime vigu
   const data = isRecord(raw) ? raw : {};
   const content = Array.isArray(data.content)
@@ -346,6 +366,60 @@ function normalizeVisitListPage(raw: unknown): Page<VisitListItemResponse> {
     last: Boolean(data.last),
     empty: Boolean(data.empty),
   };
+}
+
+function sanitizePageNumber(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.trunc(value));
+}
+
+function sanitizePageSize(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.trunc(value));
+}
+
+function buildVisitsPath(params?: VisitListQueryParams): string {
+  const url = new URL("/api/visits", "http://localhost");
+
+  if (params?.search) {
+    url.searchParams.set("search", params.search);
+  }
+
+  if (params?.status && params.status !== VISIT_STATUS_ALL) {
+    url.searchParams.set("status", params.status);
+  }
+
+  if (params?.dateFrom) {
+    url.searchParams.set("dateFrom", params.dateFrom);
+  }
+
+  if (params?.dateTo) {
+    url.searchParams.set("dateTo", params.dateTo);
+  }
+
+  if (params?.sort) {
+    url.searchParams.set("sort", params.sort);
+  }
+
+  url.searchParams.set(
+    "page",
+    String(sanitizePageNumber(params?.page, DEFAULT_VISITS_PAGE)),
+  );
+  url.searchParams.set(
+    "size",
+    String(sanitizePageSize(params?.size, DEFAULT_VISITS_PAGE_SIZE)),
+  );
+
+  return `${url.pathname}${url.search}`;
 }
 
 function normalizeTimelineEvent(
@@ -476,51 +550,33 @@ export async function getVisits(
   },
   signal?: AbortSignal,
 ): Promise<VisitListPage> {
-  const searchParams = new URLSearchParams();
+  const path = buildVisitsPath({
+    ...params,
+    page: sanitizePageNumber(params?.page, DEFAULT_VISITS_PAGE),
+    size: sanitizePageSize(params?.size, DEFAULT_VISITS_PAGE_SIZE),
+  });
+  const raw = await apiClient.get<VisitListResponsePayload>(path, { signal });
 
-  if (params?.search) {
-    searchParams.set("search", params.search);
-  }
+  return normalizeVisitCollectionResponse(raw);
+}
 
-  if (params?.status && params.status !== "all") {
-    searchParams.set("status", params.status);
-  }
+export async function getLatestVisits(
+  params?: { page?: number; size?: number },
+  signal?: AbortSignal,
+): Promise<Page<VisitListItemResponse>> {
+  const path = buildVisitsPath({
+    page: sanitizePageNumber(params?.page, DEFAULT_VISITS_PAGE),
+    size: sanitizePageSize(params?.size, DEFAULT_RECENT_VISITS_PAGE_SIZE),
+    sort: DEFAULT_RECENT_VISITS_SORT,
+  });
+  const raw = await apiClient.get<VisitListResponsePayload>(path, { signal });
 
-  if (params?.dateFrom) {
-    searchParams.set("dateFrom", params.dateFrom);
-  }
-
-  if (params?.dateTo) {
-    searchParams.set("dateTo", params.dateTo);
-  }
-
-  searchParams.set("page", String(params?.page ?? 0));
-  searchParams.set("size", String(params?.size ?? 50));
-
-  const query = searchParams.toString();
-  const path = query ? `/api/visits?${query}` : "/api/visits";
-  const raw = await apiClient.get<unknown>(path, { signal });
-
-  return normalizeVisitListResponse(raw);
+  return normalizePagedVisitCollectionResponse(raw);
 }
 
 export async function getRecentVisits(
   params?: { page?: number; size?: number },
   signal?: AbortSignal,
 ): Promise<Page<VisitListItemResponse>> {
-  const searchParams = new URLSearchParams();
-
-  // Dashboardi jaoks tahame tavaliselt sorteerida entryTime järgi kahanevalt
-  searchParams.set("sort", "entryTime,desc");
-  searchParams.set("page", String(params?.page ?? 0));
-  searchParams.set("size", String(params?.size ?? 20));
-
-  const query = searchParams.toString();
-  const path = query ? `/api/visits?${query}` : "/api/visits";
-
-  // Kutsume välja apiClient-i
-  const raw = await apiClient.get<unknown>(path, { signal });
-
-  // Kasutame uut normaliseerijat
-  return normalizeVisitListPage(raw);
+  return getLatestVisits(params, signal);
 }

--- a/lib/api/visits.ts
+++ b/lib/api/visits.ts
@@ -9,6 +9,14 @@ export interface CreateVisitRequest {
   arrivalTime?: string;
 }
 
+export interface EditVisitRequest {
+  accessPointId?: string;
+  assignorId: string;
+  entryTime?: string;
+  exitTime?: string;
+  comment?: string;
+}
+
 export interface CreateVisitResponse {
   visitId: string;
   personId: string;
@@ -62,6 +70,16 @@ export function createVisit(
 ): Promise<CreateVisitResponse> {
   return apiClient.post<CreateVisitResponse, CreateVisitRequest>(
     "/api/visits",
+    body,
+  );
+}
+
+export function editVisit(
+  visitId: string,
+  body: EditVisitRequest,
+): Promise<VisitDetailResponse> {
+  return apiClient.put<VisitDetailResponse, EditVisitRequest>(
+    `/api/visits/${visitId}`,
     body,
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@types/leaflet": "^1.9.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "date-fns": "^4.1.0",
         "hono": ">=4.12.14",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.6.0",
@@ -87,7 +86,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -632,7 +630,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -775,7 +772,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -819,7 +815,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1824,7 +1819,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
       "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.9",
@@ -2170,7 +2164,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4233,7 +4226,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4255,7 +4247,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4266,7 +4257,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4337,7 +4327,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -4876,7 +4865,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5339,7 +5327,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6335,7 +6322,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6545,7 +6531,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6859,7 +6844,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7594,7 +7578,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8497,8 +8480,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -9981,7 +9963,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10013,7 +9994,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11224,7 +11204,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11473,7 +11452,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12055,7 +12033,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
# Description

## Summary

Adds the missing `editVisit` API export and `EditVisitRequest` type to `lib/api/visits.ts` so the visit detail page can compile and update visits without import errors.

### Why

`app/(protected)/visits/[visitId]/visit-detail-page.tsx` imported `editVisit` from `@/lib/api/visits`, but that export did not exist. This caused the `/visits/[visitId]` route to fail during compilation with:

`Export editVisit doesn't exist in target module`

### Related Issue

Closes #[ISSUE_NUMBER]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Styling / UI update
- [ ] Other

## Checklist

- [x] I reviewed my own changes
- [ ] I added or updated documentation where needed
- [ ] I ran `npm run lint`
- [ ] I ran `npx prettier --check .`
- [x] My changes were tested locally
- [x] I linked the related issue
- [x] This PR is ready for review

## Screenshots

N/A

## Additional Notes

Tested locally with:

- `npm run build`

Scope was intentionally kept minimal:
- added `EditVisitRequest`
- added `editVisit(visitId, body)` using `PUT /api/visits/{visitId}`

I did run `npm run lint` and `npx prettier --check .`.
